### PR TITLE
Ruby 1.9 multibyte fix

### DIFF
--- a/lib/braintree/address/country_names.rb
+++ b/lib/braintree/address/country_names.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Braintree
   class Address
     CountryNames = [


### PR DESCRIPTION
braintree_ruby breaks in 1.9 with:

  ./braintree-2.6.0/lib/braintree/address/country_names.rb:5: invalid multibyte char (US-ASCII)

This commit adds a so-called "magic comment" to permit non-ASCII characters in Ruby 1.9. See Matz and Grey for details.

http://redmine.ruby-lang.org/issues/show/1238
http://blog.grayproductions.net/articles/ruby_19s_three_default_encodings
