### PR TITLE
Fix for URL encoded parameters causing a bogus ForgedQueryString error

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,9 @@
 == 2.13.2
 
+* Fixing parse_and_validate_query_string when the query_string contains URL-encoded parameters.
+
+== 2.13.2
+
 * Added error code for invalid purchase order number
 * Changes transparent redirect query string regexp to allow hash to appear
 anywhere in params string

--- a/lib/braintree/transparent_redirect_gateway.rb
+++ b/lib/braintree/transparent_redirect_gateway.rb
@@ -40,6 +40,7 @@ module Braintree
     def parse_and_validate_query_string(query_string) # :nodoc:
       params = Util.symbolize_keys(Util.parse_query_string(query_string))
       query_string_without_hash = query_string.split("&").reject{|param| param =~ /\Ahash=/}.join("&")
+      query_string_without_hash = Util.url_decode(query_string_without_hash)
 
       if params[:http_status] == nil
         raise UnexpectedError, "expected query string to have an http_status param"

--- a/lib/braintree/util.rb
+++ b/lib/braintree/util.rb
@@ -20,13 +20,17 @@ module Braintree
     def self.parse_query_string(qs)
       qs.split('&').inject({}) do |result, couplet|
         pair = couplet.split('=')
-        result[CGI.unescape(pair[0]).to_sym] = CGI.unescape(pair[1])
+        result[url_decode(pair[0]).to_sym] = url_decode(pair[1])
         result
       end
     end
 
     def self.url_encode(text)
       CGI.escape text.to_s
+    end
+
+    def self.url_decode(text)
+      CGI.unescape text.to_s
     end
 
     def self.symbolize_keys(hash)


### PR DESCRIPTION
We noticed a problem where users whose query strings came back to us still url-encoded would cause a ForgedQueryString to occur. So for example, this type of query string was fine:

"http_status=200&id=8pqwmq2b459cxfkd&kind=create_customer&billing_credit_card_subscription[processor_plan_id]=solo_monthly&billing_credit_card_subscription[total_users]=1&hash=afd187d2f546d60f8faad923d6818aedc85e5a97"

Notice the square brackets are not url-encoded.

This type of request, on the other hand, would always fail:

"http_status=200&id=c287ttnpywp4y4jt&kind=create_customer&billing_credit_card_subscription%5Bprocessor_plan_id%5D=basic_monthly&billing_credit_card_subscription%5Btotal_users%5D=5&hash=13feede0d99a8d7480e27dc0c4fb754e8c2f5212" 

Notice the square brackets _are_ url-encoded in the failing case.

We're not sure why the parameters are coming back encoded in some cases and in others not--maybe browser differences or a proxy is re-writing them incorrectly. 

At any rate, this patch adds a test case and always decodes the query string before re-hashing it.
