### PR TITLE
Include all files under spec/ in gemspec.

### DIFF
--- a/braintree.gemspec
+++ b/braintree.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://www.braintreepayments.com/"
   s.rubyforge_project = "braintree"
   s.has_rdoc = false
-  s.files = Dir.glob ["README.rdoc", "LICENSE", "{lib,spec}/**/*.rb", "lib/**/*.crt", "*.gemspec"]
+  s.files = Dir.glob ["README.rdoc", "LICENSE", "lib/**/*.{rb,crt}", "spec/**/*", "*.gemspec"]
   s.add_dependency "builder", ">= 2.0.0"
 end
 


### PR DESCRIPTION
I noticed that e.g. `spec/ssl/privateKey.key` isn't included with the current pattern of `s.files` in the gemspec.

My use case is for [fake_braintree](https://github.com/thoughtbot/fake_braintree) - I'd like to run the Braintree integration specs against the fake_braintree server (!!), but without the `privateKey.key`, there are a bunch of `ECONNREFUSED` errors.

Let me know if the use case is confusing.
