### PR TITLE
Set Content-Length header on empty post/put bodys

### DIFF
--- a/lib/braintree/http.rb
+++ b/lib/braintree/http.rb
@@ -42,7 +42,7 @@ module Braintree
     end
 
     def _build_xml(params)
-      return nil if params.nil?
+      return "" if params.nil?
       Braintree::Xml.hash_to_xml params
     end
 


### PR DESCRIPTION
I've been working on getting fake_braintree to work with WEBrick instead
of Thin for JRuby compatibility. WEBrick won't accept POST or PUT
requests without a Content-Length header and the Braintree client were
creating those in some cases.

This commit makes the Braintree client use "" instead of nil as an
argument to Net::HTTP::Post and Net::HTTP::Put since this triggers makes
Net::HTTP add the Content-Length header.
