### PR TITLE
allow a query parameter with no value

### DIFF
--- a/lib/braintree/util.rb
+++ b/lib/braintree/util.rb
@@ -20,7 +20,7 @@ module Braintree
     def self.parse_query_string(qs)
       qs.split('&').inject({}) do |result, couplet|
         pair = couplet.split('=')
-        result[CGI.unescape(pair[0]).to_sym] = CGI.unescape(pair[1])
+        result[CGI.unescape(pair[0]).to_sym] = CGI.unescape(pair[1] || '')
         result
       end
     end

--- a/spec/unit/braintree/util_spec.rb
+++ b/spec/unit/braintree/util_spec.rb
@@ -192,6 +192,11 @@ describe Braintree::Util do
       query_string = "foo=bar%20baz&hash=a1b2c3"
       Braintree::Util.parse_query_string(query_string).should == {:foo => "bar baz", :hash => "a1b2c3"}
     end
+
+    it "does not fail if there with a blank value" do
+      query_string = "foo=bar%20baz&hash=a1b2c3&vat_number="
+      Braintree::Util.parse_query_string(query_string).should == {:foo => "bar baz", :hash => "a1b2c3", :vat_number => ""}
+    end
   end
 
   describe "self.raise_exception_for_status_code" do


### PR DESCRIPTION
If, for some reason, the after request gets parameters with no value. eg:

```
/after_payment?http_status=200&id=rmvv3pzx77pmgsvv&kind=create_payment_method&vat_number=&hash=e4b312bc2aa5f77a85e22cb796fbc5c59d67410f
```

Here, the `vat_number` parameter is present, but has no value (or a blank one).
This currently fails, as the library tries to get the value but can't unescape nil.

This replaces the nil value by a blank value, therefore not removing the key, but not failing either because it' can't be escaped.
