### PR TITLE
Add 'default_credit_card' method to Customer

### DIFF
--- a/lib/braintree/customer.rb
+++ b/lib/braintree/customer.rb
@@ -157,6 +157,11 @@ module Braintree
       @gateway.customer.transactions(id, options)
     end
 
+    # Returns the default +CreditCard+ for the customer.
+    def default_credit_card
+      @credit_cards.find {|credit_card| credit_card.default? }
+    end
+
     # Deprecated. Use Braintree::Customer.update
     #
     # See http://www.braintreepayments.com/docs/ruby/customers/update


### PR DESCRIPTION
This pull request let's you write:

``` ruby
customer = Braintree::Customer.find("a_customer_id")
customer.default_credit_card
```

Having the customer you can get his _default_credit_card_.
