### PR TITLE
Exclude private key from inspect

### DIFF
--- a/lib/braintree/configuration.rb
+++ b/lib/braintree/configuration.rb
@@ -126,6 +126,14 @@ module Braintree
       base_user_agent = "Braintree Ruby Gem #{Braintree::Version::String}"
       @custom_user_agent ? "#{base_user_agent} (#{@custom_user_agent})" : base_user_agent
     end
+    
+    def inspect # :nodoc:
+      nice_attributes = self.class._attributes.map { |attr|
+        # avoid leaking the private key into logs etc.
+        "#{attr}: #{send(attr).inspect}" unless attr == :private_key
+      }.compact
+      "#<#{self.class} #{nice_attributes.join(', ')}>"
+    end
 
     def self._default_logger # :nodoc:
       logger = Logger.new(STDOUT)


### PR DESCRIPTION
Exclude private key when inspecting braintree configuration. Although one could argue that dumping inspect into production logs is a bad idea (it is), this change makes it less likely that private keys are leaked.

Comments are much appreciated! Maybe there is a better way of solving this?
