### PR TITLE
Update credit_card_gateway.rb

### DIFF
--- a/lib/braintree/credit_card_gateway.rb
+++ b/lib/braintree/credit_card_gateway.rb
@@ -89,6 +89,7 @@ module Braintree
         options << :fail_on_duplicate_payment_method
         signature << :customer_id
       when :update
+        options << :fail_on_duplicate_payment_method
         billing_address_params << {:options => [:update_existing]}
       else
         raise ArgumentError


### PR DESCRIPTION
One should be able to configure 'fail_on_duplicate_payment_method' for updates - otherwise someone could create a credit card, then 'update' their credit card and enter in a duplicate. This patch was tested and works with:

```
  @tr_data = Braintree::TransparentRedirect.update_customer_data(
      :redirect_url => shop_braintree_update_callback_url,
      :customer_id => current_user.id,
      :customer => {
          :id => current_user.id,
          :credit_card => {
              :options => {
                  :update_existing_token => billing_info[:cc_token],
                  :verify_card => true,
                  :fail_on_duplicate_payment_method => true
              },
              :billing_address => {
                  :options => {
                      :update_existing => true
                  }
              }
          }
      }
  )
```
