### PR TITLE
Work around transaction search timeouts in the client

### DIFF
--- a/lib/braintree/transaction_gateway.rb
+++ b/lib/braintree/transaction_gateway.rb
@@ -141,6 +141,24 @@ module Braintree
       response = @config.http.post "/transactions/advanced_search", {:search => search.to_hash}
       attributes = response[:credit_card_transactions]
       Util.extract_attribute_as_array(attributes, :transaction).map { |attrs| Transaction._new(@gateway, attrs) }
+
+    rescue Braintree::UnexpectedError
+      if $!.to_s =~ /Unprocessable entity/ && ids.size > 1
+        # Act under the belief that this is a server-side timeout, not a real invalid
+        # request. In that case, we can work around this client-side by requesting
+        # fewer IDs -- say, by splitting the request in half -- and trying again.
+        #
+        # Yes, this is recursive.
+        #
+        # https://en.wikipedia.org/wiki/The_Sorcerer's_Apprentice
+        brooms = [[], []]
+        ids.each_with_index { |id,i|
+          brooms[i % 2] << id
+        }
+        _fetch_transactions(search, brooms[0]) + _fetch_transactions(search, brooms[1])
+      else
+        raise
+      end
     end
   end
 end


### PR DESCRIPTION
As promised, here's a client-side fix to the transaction timeout search issue in #46. It works by catching the `422 Unprocessable entity` responses and retrying with two smaller requests -- recursively.

![brooms](https://f.cloud.github.com/assets/118362/1696050/d72f4e5a-5ebc-11e3-92c3-50f05e5d7cf7.jpg)

I believe #55 is the right solution, but this would work too.
