### PR TITLE
Use OpenSSL::Digest instead of deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/braintree/digest.rb
+++ b/lib/braintree/digest.rb
@@ -20,7 +20,7 @@ module Braintree
 
     def self._hmac_sha1(key, message)
       key_digest = ::Digest::SHA1.digest(key)
-      sha1 = OpenSSL::Digest::Digest.new("sha1")
+      sha1 = OpenSSL::Digest.new("sha1")
       OpenSSL::HMAC.hexdigest(sha1, key_digest, message.to_s)
     end
   end


### PR DESCRIPTION
OpenSSL::Digest::Digest has been deprecated because it is from an older Ruby 1.8 era https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51
and finally is giving deprecation warnings with Ruby 2.1.0: ruby/ruby#446
