### PR TITLE
release 2.28.1 version

### DIFF
--- a/lib/braintree/version.rb
+++ b/lib/braintree/version.rb
@@ -2,7 +2,7 @@ module Braintree
   module Version
     Major = 2
     Minor = 28
-    Tiny = 0
+    Tiny = 1
 
     String = "#{Major}.#{Minor}.#{Tiny}"
   end


### PR DESCRIPTION
As far as I can see the only change on that would be https://github.com/braintree/braintree_ruby/commit/84d6e96152473162a84e0aea44c67862cffce0d5 . So we could release a minor release to get rid of deprecation warns =)

thanks
