### PR TITLE
Optional client side encryption key attribute

### DIFF
--- a/lib/braintree/configuration.rb
+++ b/lib/braintree/configuration.rb
@@ -20,6 +20,15 @@ module Braintree
     end
     expectant_reader :environment, :merchant_id, :public_key, :private_key
 
+    def self.optional_reader(*attributes) # :nodoc:
+      attributes.each do |attribute|
+        (class << self; self; end).send(:define_method, attribute) do
+          instance_variable_get("@#{attribute}")
+        end
+      end
+    end
+    optional_reader :client_side_encryption_key
+
     # Sets the Braintree environment to use. Valid values are <tt>:sandbox</tt> and <tt>:production</tt>
     def self.environment=(env)
       unless [:development, :qa, :sandbox, :production].include?(env)


### PR DESCRIPTION
Hey guys.

Just started working on a new payment gateway and wanted a way to organise the the braintree.js key with the other braintree configuration settings. Also since the use of braintree.js is optional I made the configuration attribute optional so the gem won't complain if its not used.

I just thought since many web-apps would be using a combination of server-server api and the js api.
