### PR TITLE
use config instance in the WebhookTestingGateway

### DIFF
--- a/lib/braintree/webhook_testing_gateway.rb
+++ b/lib/braintree/webhook_testing_gateway.rb
@@ -7,7 +7,7 @@ module Braintree
 
     def sample_notification(kind, id)
       payload = Base64.encode64(_sample_xml(kind, id))
-      signature_string = "#{Braintree::Configuration.public_key}|#{Braintree::Digest.hexdigest(Braintree::Configuration.private_key, payload)}"
+      signature_string = "#{@config.public_key}|#{Braintree::Digest.hexdigest(@config.private_key, payload)}"
 
       return signature_string, payload
     end


### PR DESCRIPTION
Using the config instance instead of Braintree::Configuration so that the `sample_notification` method will work via  `Braintree::Gateway.new(config).webhook_testing.sample_notification`.

I did a quick grep and this looked like the only occurrence of the static configuration being used instead of the instance.
