### PR TITLE
fixes the checks to see whether LibXML is defined.  It needs to check for...

### DIFF
--- a/lib/braintree/xml/parser.rb
+++ b/lib/braintree/xml/parser.rb
@@ -19,7 +19,7 @@ module Braintree
       end
 
       def self._determine_parser
-        if defined?(::LibXml::XML) && ::LibXml::XML.respond_to?(:default_keep_blanks=)
+        if defined?(::LibXML::XML) && ::LibXML::XML.respond_to?(:default_keep_blanks=)
           ::Braintree::Xml::Libxml
         else
           ::Braintree::Xml::Rexml


### PR DESCRIPTION
... LibXML not LibXml.

I noticed performance problems while using the gem and discovered that it was always using the MUCH slower REXML even though I had installed LibXML.  This fixes the code that checks for whether LibXML is installed/defined.
