### PR TITLE
Adds installation instructions and signup information to the README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -7,6 +7,14 @@ The Braintree gem provides integration access to the Braintree Gateway.
 * builder
 * libxml-ruby
 
+== Installation
+
+  gem install braintree
+
+Or add to your Gemfile:
+
+  gem 'braintree'
+
 == Quick Start Example
 
   require "rubygems"
@@ -16,6 +24,8 @@ The Braintree gem provides integration access to the Braintree Gateway.
   Braintree::Configuration.merchant_id = "your_merchant_id"
   Braintree::Configuration.public_key = "your_public_key"
   Braintree::Configuration.private_key = "your_private_key"
+
+  You receive the above mentioned merchant id, public key, and private key upon signing up for Braintree. Signing up for a sandbox account is easy, free, and automatic, and you can do that right * here [https://www.braintreepayments.com/get-started].
 
   result = Braintree::Transaction.sale(
     :amount => "1000.00",


### PR DESCRIPTION
Dear Braintree,

I added instructions for how to install the gem as well as information about where the merchant id and keys come from, along with a link to the sandbox signup page. I did not make any changes to the changelog (as one might do for a pull request to Rails) because it looks like you use your changelog mostly for functionality changes upon version increases. 

Chelsea