### PR TITLE
Remove usage of deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/braintree/sha256_digest.rb
+++ b/lib/braintree/sha256_digest.rb
@@ -6,7 +6,7 @@ module Braintree
 
     def self._hmac(key, message)
       key_digest = ::Digest::SHA256.digest(key)
-      sha256 = OpenSSL::Digest::Digest.new("sha256")
+      sha256 = OpenSSL::Digest.new("sha256")
       OpenSSL::HMAC.hexdigest(sha256, key_digest, message.to_s)
     end
   end


### PR DESCRIPTION
`OpenSSL::Digest::Digest` has been deprecated in favour of `OpenSSL::Digest`.  Avoid warnings by switching to the newer constant.
