### PR TITLE
Add Braintree::PaymentMethod.from_nonce

### DIFF
--- a/lib/braintree/payment_method.rb
+++ b/lib/braintree/payment_method.rb
@@ -10,6 +10,10 @@ module Braintree
       Configuration.gateway.payment_method.find(token)
     end
 
+    def self.from_nonce(nonce)
+      Configuration.gateway.payment_method.from_nonce(nonce)
+    end
+
     def self.update(token, attributes)
       Configuration.gateway.payment_method.update(token, attributes)
     end


### PR DESCRIPTION
Copying Braintree::CreditCard.from_nonce across to PaymentMethod as it is not specific CreditCard.
Currently you can call Braintree::CreditCard.from_nonce(paypal_nonce) and it will throw a cryptic `nil doesn't respond to each` error.

I haven't bothered with tests as it looks like only Braintree devs can actually run the suite.