### PR TITLE
Bump libxml-ruby to 2.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ if RUBY_VERSION.start_with?('1.8')
   gem 'libxml-ruby', '1.1.3'
   gem 'json'
 else
-  gem 'libxml-ruby', '2.6.0'
+  gem 'libxml-ruby', '2.8.0'
 end
 
 gem 'rake_commit', '1.0.1'


### PR DESCRIPTION
The 2.6.0 version of this gem fails to compile on my Ruby 2.2.3 install. This was [fixed in 2.8.0 of the gem](https://github.com/xml4r/libxml-ruby/blob/master/HISTORY#L3-L5).

All unit tests pass with this change.