### PR TITLE
Remove duplicate :environment from expectant_reader

### DIFF
--- a/lib/braintree/configuration.rb
+++ b/lib/braintree/configuration.rb
@@ -39,7 +39,7 @@ module Braintree
         end
       end
     end
-    expectant_reader *([:environment] + READABLE_ATTRIBUTES)
+    expectant_reader *READABLE_ATTRIBUTES
 
     # Sets the Braintree environment to use. Valid values are <tt>:sandbox</tt> and <tt>:production</tt>
     def self.environment=(env)


### PR DESCRIPTION
:environment is already included in READABLE_ATTRIBUTES