### PR TITLE
No need to call .dup since Array#+ doesn't mutate the original array

### DIFF
--- a/lib/braintree/customer.rb
+++ b/lib/braintree/customer.rb
@@ -126,12 +126,12 @@ module Braintree
     # Returns the customer's payment methods
     def payment_methods
       @credit_cards +
-        @paypal_accounts.dup +
-        @apple_pay_cards.dup +
-        @coinbase_accounts.dup +
-        @android_pay_cards.dup +
-        @amex_express_checkout_cards.dup +
-        @venmo_accounts.dup
+        @paypal_accounts +
+        @apple_pay_cards +
+        @coinbase_accounts +
+        @android_pay_cards +
+        @amex_express_checkout_cards +
+        @venmo_accounts
     end
 
     def inspect # :nodoc:


### PR DESCRIPTION
See docs for Array#+

http://ruby-doc.org/core-1.8.7/Array.html#method-i-2B
http://ruby-doc.org/core-1.9.3/Array.html#method-i-2B
http://ruby-doc.org/core-2.2.3/Array.html#method-i-2B