### PR TITLE
Pass configured gateway to Merchant#_new instead of using global gateway

### DIFF
--- a/lib/braintree/merchant.rb
+++ b/lib/braintree/merchant.rb
@@ -4,9 +4,9 @@ module Braintree
 
     attr_reader :id, :email, :company_name, :country_code_alpha2, :country_code_alpha3, :country_code_numeric, :country_name, :merchant_accounts
 
-    def initialize(attributes) # :nodoc:
+    def initialize(gateway, attributes) # :nodoc:
       @merchant_accounts = attributes.delete(:merchant_accounts).map do |merchant_account|
-        MerchantAccount._new(Configuration.gateway, merchant_account)
+        MerchantAccount._new(gateway, merchant_account)
       end
 
       set_instance_variables_from_hash(attributes)

--- a/lib/braintree/merchant_gateway.rb
+++ b/lib/braintree/merchant_gateway.rb
@@ -25,7 +25,7 @@ module Braintree
 
       if response.has_key?(:response) && response[:response][:merchant]
         Braintree::SuccessfulResult.new(
-          :merchant => Merchant._new(response[:response][:merchant]),
+          :merchant => Merchant._new(@gateway, response[:response][:merchant]),
           :credentials => OAuthCredentials._new(response[:response][:credentials])
         )
       elsif response[:api_error_response]


### PR DESCRIPTION
### What
Pass in the configured gateway when calling `Merchant#_new`. This allows a merchant to be created without calling `Braintree::Configuration.merchant_id = <merchant_id>`

### Why
Without this change we encounter an error when trying to create a new merchant account without globally configuring a merchant id. It doesn't seem correct to require `Braintree::Configuration.merchant_id` to be set globally before a merchant is created. The error is as follows:
```ruby
gateway = Braintree::Gateway.new(client_id: client_id, client_secret: client_secret)
gateway.merchant.create(email: email, country_code_alpha2: country_code_alpha2, company_name: company_name)
I, [2017-05-11T09:50:30.823048 #32471]  INFO -- : [Braintree] [10/May/2017 23:50:30 UTC] POST /merchants/create_via_api 201
Braintree::ConfigurationError: Braintree::Configuration.merchant_id needs to be set
```

