### PR TITLE
Add ruby 2.4 compatibility for the Xml Generator.

### DIFF
--- a/lib/braintree/xml/generator.rb
+++ b/lib/braintree/xml/generator.rb
@@ -6,6 +6,7 @@ module Braintree
       XML_TYPE_NAMES = {
         "Fixnum"     => "integer",
         "Bignum"     => "integer",
+        "Integer"    => "integer",
         "TrueClass"  => "boolean",
         "FalseClass" => "boolean",
         "Date"       => "datetime",

--- a/spec/unit/braintree/xml_spec.rb
+++ b/spec/unit/braintree/xml_spec.rb
@@ -99,6 +99,13 @@ describe Braintree::Xml do
       verify_to_xml_and_back hash
     end
 
+		context "Integer" do
+			it "works for integers" do
+				hash = { :root => {:foo => 1 } }
+				Braintree::Xml.hash_to_xml(hash).should include("<foo type=\"integer\">1</foo>")
+			end
+		end
+
 		context "BigDecimal" do
 			it "works for BigDecimals" do
 				hash = {:root => {:foo => BigDecimal.new("123.45")}}


### PR DESCRIPTION
Fixnum and Bignum have been unified into the Integer class in ruby 2.4.

This change programs the Xml Generator to serialize constant
integers as type="integer" instead of no type (strings).