### PR TITLE
Cleanup - Consistent attr_reader declarations

### DIFF
--- a/lib/braintree/account_updater_daily_report.rb
+++ b/lib/braintree/account_updater_daily_report.rb
@@ -2,8 +2,7 @@ module Braintree
   class AccountUpdaterDailyReport # :nodoc:
     include BaseModule
 
-    attr_reader :report_url
-    attr_reader :report_date
+    attr_reader :report_url, :report_date
 
     class << self
       protected :new

--- a/lib/braintree/address.rb
+++ b/lib/braintree/address.rb
@@ -2,9 +2,22 @@ module Braintree
   class Address
     include BaseModule # :nodoc:
 
-    attr_reader :company, :country_name, :created_at, :customer_id, :extended_address, :first_name, :id,
-      :last_name, :locality, :postal_code, :region, :street_address, :updated_at,
-      :country_code_alpha2, :country_code_alpha3, :country_code_numeric
+    attr_reader :company
+    attr_reader :country_code_alpha2
+    attr_reader :country_code_alpha3
+    attr_reader :country_code_numeric
+    attr_reader :country_name
+    attr_reader :created_at
+    attr_reader :customer_id
+    attr_reader :extended_address
+    attr_reader :first_name
+    attr_reader :id
+    attr_reader :last_name
+    attr_reader :locality
+    attr_reader :postal_code
+    attr_reader :region
+    attr_reader :street_address
+    attr_reader :updated_at
 
     def self.create(attributes)
       Configuration.gateway.address.create(attributes)

--- a/lib/braintree/amex_express_checkout_card.rb
+++ b/lib/braintree/amex_express_checkout_card.rb
@@ -2,8 +2,20 @@ module Braintree
   class AmexExpressCheckoutCard
     include BaseModule # :nodoc:
 
-    attr_reader :bin, :card_member_expiry_date, :card_member_number, :card_type, :created_at, :customer_id, :default,
-      :expiration_month, :expiration_year, :image_url, :source_description, :subscriptions, :token, :updated_at
+    attr_reader :bin
+    attr_reader :card_member_expiry_date
+    attr_reader :card_member_number
+    attr_reader :card_type
+    attr_reader :created_at
+    attr_reader :customer_id
+    attr_reader :default
+    attr_reader :expiration_month
+    attr_reader :expiration_year
+    attr_reader :image_url
+    attr_reader :source_description
+    attr_reader :subscriptions
+    attr_reader :token
+    attr_reader :updated_at
 
     def initialize(gateway, attributes) # :nodoc:
       @gateway = gateway

--- a/lib/braintree/android_pay_card.rb
+++ b/lib/braintree/android_pay_card.rb
@@ -2,9 +2,22 @@ module Braintree
   class AndroidPayCard
     include BaseModule # :nodoc:
 
-    attr_reader :token, :virtual_card_type, :virtual_card_last_4, :source_card_type, :source_card_last_4,
-      :expiration_month, :expiration_year, :created_at, :updated_at, :image_url, :subscriptions, :bin,
-      :google_transaction_id, :default, :source_description, :customer_id
+    attr_reader :bin
+    attr_reader :created_at
+    attr_reader :customer_id
+    attr_reader :default
+    attr_reader :expiration_month
+    attr_reader :expiration_year
+    attr_reader :google_transaction_id
+    attr_reader :image_url
+    attr_reader :source_card_last_4
+    attr_reader :source_card_type
+    attr_reader :source_description
+    attr_reader :subscriptions
+    attr_reader :token
+    attr_reader :updated_at
+    attr_reader :virtual_card_last_4
+    attr_reader :virtual_card_type
 
     def initialize(gateway, attributes) # :nodoc:
       @gateway = gateway

--- a/lib/braintree/apple_pay_card.rb
+++ b/lib/braintree/apple_pay_card.rb
@@ -10,9 +10,21 @@ module Braintree
       All = constants.map { |c| const_get(c) }
     end
 
-    attr_reader :bin, :card_type, :created_at, :customer_id, :default, :expiration_month,
-      :expiration_year, :expired, :image_url, :last_4, :payment_instrument_name,
-      :source_description, :subscriptions, :token, :updated_at
+    attr_reader :bin
+    attr_reader :card_type
+    attr_reader :created_at
+    attr_reader :customer_id
+    attr_reader :default
+    attr_reader :expiration_month
+    attr_reader :expiration_year
+    attr_reader :expired
+    attr_reader :image_url
+    attr_reader :last_4
+    attr_reader :payment_instrument_name
+    attr_reader :source_description
+    attr_reader :subscriptions
+    attr_reader :token
+    attr_reader :updated_at
 
     def initialize(gateway, attributes) # :nodoc:
       @gateway = gateway

--- a/lib/braintree/authorization_adjustment.rb
+++ b/lib/braintree/authorization_adjustment.rb
@@ -2,9 +2,7 @@ module Braintree
   class AuthorizationAdjustment # :nodoc:
     include BaseModule
 
-    attr_reader :amount
-    attr_reader :success
-    attr_reader :timestamp
+    attr_reader :amount, :success, :timestamp
 
     class << self
       protected :new

--- a/lib/braintree/bin_data.rb
+++ b/lib/braintree/bin_data.rb
@@ -2,8 +2,15 @@ module Braintree
   class BinData # :nodoc:
     include BaseModule
 
-    attr_reader :commercial, :country_of_issuance, :debit, :durbin_regulated, :healthcare,
-      :issuing_bank, :payroll, :prepaid, :product_id
+    attr_reader :commercial
+    attr_reader :country_of_issuance
+    attr_reader :debit
+    attr_reader :durbin_regulated
+    attr_reader :healthcare
+    attr_reader :issuing_bank
+    attr_reader :payroll
+    attr_reader :prepaid
+    attr_reader :product_id
 
     def initialize(attributes)
       set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/coinbase_account.rb
+++ b/lib/braintree/coinbase_account.rb
@@ -2,7 +2,16 @@ module Braintree
   class CoinbaseAccount
     include BaseModule # :nodoc:
 
-    attr_reader :token, :user_id, :user_email, :user_name, :subscriptions, :created_at, :updated_at, :default, :customer_id
+    attr_reader :created_at
+    attr_reader :customer_id
+    attr_reader :default
+    attr_reader :subscriptions
+    attr_reader :token
+    attr_reader :updated_at
+    attr_reader :user_email
+    attr_reader :user_id
+    attr_reader :user_name
+
     def initialize(gateway, attributes) # :nodoc:
       @gateway = gateway
       set_instance_variables_from_hash(attributes)

--- a/lib/braintree/credit_card.rb
+++ b/lib/braintree/credit_card.rb
@@ -35,10 +35,30 @@ module Braintree
     Commercial = Debit = DurbinRegulated = Healthcare = Payroll = Prepaid = ProductId =
       IssuingBank = CountryOfIssuance = CardTypeIndicator
 
-    attr_reader :billing_address, :bin, :card_type, :cardholder_name, :commercial, :country_of_issuance,
-      :created_at, :customer_id, :debit, :durbin_regulated, :expiration_month, :expiration_year, :healthcare,
-      :issuing_bank, :last_4, :payroll, :prepaid, :product_id, :subscriptions, :token, :unique_number_identifier, :updated_at,
-      :image_url, :verification
+    attr_reader :billing_address
+    attr_reader :bin
+    attr_reader :card_type
+    attr_reader :cardholder_name
+    attr_reader :commercial
+    attr_reader :country_of_issuance
+    attr_reader :created_at
+    attr_reader :customer_id
+    attr_reader :debit
+    attr_reader :durbin_regulated
+    attr_reader :expiration_month
+    attr_reader :expiration_year
+    attr_reader :healthcare
+    attr_reader :image_url
+    attr_reader :issuing_bank
+    attr_reader :last_4
+    attr_reader :payroll
+    attr_reader :prepaid
+    attr_reader :product_id
+    attr_reader :subscriptions
+    attr_reader :token
+    attr_reader :unique_number_identifier
+    attr_reader :updated_at
+    attr_reader :verification
 
     def self.create(attributes)
       Configuration.gateway.credit_card.create(attributes)

--- a/lib/braintree/credit_card_verification.rb
+++ b/lib/braintree/credit_card_verification.rb
@@ -11,10 +11,22 @@ module Braintree
       All = [Failed, GatewayRejected, ProcessorDeclined, Verified]
     end
 
-    attr_reader :avs_error_response_code, :avs_postal_code_response_code, :avs_street_address_response_code,
-      :cvv_response_code, :merchant_account_id, :processor_response_code, :processor_response_text, :status,
-      :amount, :currency_iso_code, :id, :gateway_rejection_reason, :credit_card, :billing, :created_at,
-      :risk_data
+    attr_reader :amount
+    attr_reader :avs_error_response_code
+    attr_reader :avs_postal_code_response_code
+    attr_reader :avs_street_address_response_code
+    attr_reader :billing
+    attr_reader :created_at
+    attr_reader :credit_card
+    attr_reader :currency_iso_code
+    attr_reader :cvv_response_code
+    attr_reader :gateway_rejection_reason
+    attr_reader :id
+    attr_reader :merchant_account_id
+    attr_reader :processor_response_code
+    attr_reader :processor_response_text
+    attr_reader :risk_data
+    attr_reader :status
 
     def initialize(attributes) # :nodoc:
       set_instance_variables_from_hash(attributes)
@@ -26,11 +38,21 @@ module Braintree
 
     def inspect # :nodoc:
       attr_order = [
-        :status, :processor_response_code, :processor_response_text,
-        :amount, :currency_iso_code,
-        :cvv_response_code, :avs_error_response_code,
-        :avs_postal_code_response_code, :avs_street_address_response_code,
-        :merchant_account_id, :gateway_rejection_reason, :id, :credit_card, :billing, :created_at
+        :status,
+        :processor_response_code,
+        :processor_response_text,
+        :amount,
+        :currency_iso_code,
+        :cvv_response_code,
+        :avs_error_response_code,
+        :avs_postal_code_response_code,
+        :avs_street_address_response_code,
+        :merchant_account_id,
+        :gateway_rejection_reason,
+        :id,
+        :credit_card,
+        :billing,
+        :created_at
       ]
       formatted_attrs = attr_order.map do |attr|
         if attr == :amount

--- a/lib/braintree/customer.rb
+++ b/lib/braintree/customer.rb
@@ -2,10 +2,28 @@ module Braintree
   class Customer
     include BaseModule
 
-    attr_reader :addresses, :company, :created_at, :credit_cards, :email, :fax, :first_name, :id, :last_name,
-      :phone, :updated_at, :website, :custom_fields, :paypal_accounts, :apple_pay_cards, :coinbase_accounts,
-      :android_pay_cards, :amex_express_checkout_cards, :venmo_accounts, :us_bank_accounts, :visa_checkout_cards,
-      :masterpass_cards
+    attr_reader :addresses
+    attr_reader :amex_express_checkout_cards
+    attr_reader :android_pay_cards
+    attr_reader :apple_pay_cards
+    attr_reader :coinbase_accounts
+    attr_reader :company
+    attr_reader :created_at
+    attr_reader :credit_cards
+    attr_reader :custom_fields
+    attr_reader :email
+    attr_reader :fax
+    attr_reader :first_name
+    attr_reader :id
+    attr_reader :last_name
+    attr_reader :masterpass_cards
+    attr_reader :paypal_accounts
+    attr_reader :phone
+    attr_reader :updated_at
+    attr_reader :us_bank_accounts
+    attr_reader :venmo_accounts
+    attr_reader :visa_checkout_cards
+    attr_reader :website
 
     def self.all
       Configuration.gateway.customer.all

--- a/lib/braintree/disbursement.rb
+++ b/lib/braintree/disbursement.rb
@@ -2,7 +2,15 @@ module Braintree
   class Disbursement
     include BaseModule
 
-    attr_reader :id, :amount, :exception_message, :disbursement_date, :follow_up_action, :merchant_account, :transaction_ids, :retry, :success
+    attr_reader :amount
+    attr_reader :disbursement_date
+    attr_reader :exception_message
+    attr_reader :follow_up_action
+    attr_reader :id
+    attr_reader :merchant_account
+    attr_reader :retry
+    attr_reader :success
+    attr_reader :transaction_ids
 
     alias_method :success?, :success
 

--- a/lib/braintree/dispute/evidence.rb
+++ b/lib/braintree/dispute/evidence.rb
@@ -3,11 +3,7 @@ module Braintree
     class Evidence # :nodoc:
       include BaseModule
 
-      attr_reader :comment
-      attr_reader :created_at
-      attr_reader :id
-      attr_reader :sent_to_processor_at
-      attr_reader :url
+      attr_reader :comment, :created_at, :id, :sent_to_processor_at, :url
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/dispute/history_event.rb
+++ b/lib/braintree/dispute/history_event.rb
@@ -3,8 +3,7 @@ module Braintree
     class HistoryEvent # :nodoc:
       include BaseModule
 
-      attr_reader :status
-      attr_reader :timestamp
+      attr_reader :status, :timestamp
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/dispute/transaction.rb
+++ b/lib/braintree/dispute/transaction.rb
@@ -3,11 +3,7 @@ module Braintree
     class Transaction # :nodoc:
       include BaseModule
 
-      attr_reader :amount
-      attr_reader :id
-      attr_reader :order_id
-      attr_reader :purchase_order_number
-      attr_reader :payment_instrument_subtype
+      attr_reader :amount, :id, :order_id, :purchase_order_number, :payment_instrument_subtype
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/error_result.rb
+++ b/lib/braintree/error_result.rb
@@ -1,7 +1,14 @@
 module Braintree
   class ErrorResult
 
-    attr_reader :credit_card_verification, :merchant_account, :transaction, :subscription, :errors, :params, :message, :verification
+    attr_reader :credit_card_verification
+    attr_reader :errors
+    attr_reader :merchant_account
+    attr_reader :message
+    attr_reader :params
+    attr_reader :subscription
+    attr_reader :transaction
+    attr_reader :verification
 
     def initialize(gateway, data) # :nodoc:
       @gateway = gateway

--- a/lib/braintree/granted_payment_instrument_update.rb
+++ b/lib/braintree/granted_payment_instrument_update.rb
@@ -2,7 +2,11 @@ module Braintree
   class GrantedPaymentInstrumentUpdate
     include BaseModule
 
-    attr_reader :grant_owner_merchant_id, :grant_recipient_merchant_id, :payment_method_nonce, :token, :updated_fields
+    attr_reader :grant_owner_merchant_id
+    attr_reader :grant_recipient_merchant_id
+    attr_reader :payment_method_nonce
+    attr_reader :token
+    attr_reader :updated_fields
 
     def initialize(attributes)
       set_instance_variables_from_hash(attributes)

--- a/lib/braintree/ideal_payment.rb
+++ b/lib/braintree/ideal_payment.rb
@@ -2,7 +2,15 @@ module Braintree
   class IdealPayment
     include BaseModule
 
-    attr_reader :id, :ideal_transaction_id, :currency, :amount, :status, :order_id, :issuer, :approval_url, :iban_bank_account
+    attr_reader :amount
+    attr_reader :approval_url
+    attr_reader :currency
+    attr_reader :iban_bank_account
+    attr_reader :id
+    attr_reader :ideal_transaction_id
+    attr_reader :issuer
+    attr_reader :order_id
+    attr_reader :status
 
     def initialize(gateway, attributes) # :nodoc:
       @gateway = gateway
@@ -36,7 +44,12 @@ module Braintree
 
     class IbanBankAccount
       include BaseModule
-      attr_reader :account_holder_name, :bic, :masked_iban, :iban_account_number_last_4, :iban_country, :description
+      attr_reader :account_holder_name
+      attr_reader :bic
+      attr_reader :description
+      attr_reader :iban_account_number_last_4
+      attr_reader :iban_country
+      attr_reader :masked_iban
 
       def initialize(attributes) # :nodoc:
         set_instance_variables_from_hash(attributes)

--- a/lib/braintree/masterpass_card.rb
+++ b/lib/braintree/masterpass_card.rb
@@ -2,12 +2,31 @@ module Braintree
   class MasterpassCard
     include BaseModule # :nodoc:
 
-    attr_reader :billing_address, :bin, :card_type, :cardholder_name,
-      :commercial, :country_of_issuance, :created_at, :customer_id,
-      :customer_location, :debit, :durbin_regulated, :expiration_month,
-      :expiration_year, :healthcare, :issuing_bank, :last_4, :payroll,
-      :prepaid, :product_id, :subscriptions, :token, :unique_number_identifier,
-      :updated_at, :image_url, :verification
+    attr_reader :billing_address
+    attr_reader :bin
+    attr_reader :card_type
+    attr_reader :cardholder_name
+    attr_reader :commercial
+    attr_reader :country_of_issuance
+    attr_reader :created_at
+    attr_reader :customer_id
+    attr_reader :customer_location
+    attr_reader :debit
+    attr_reader :durbin_regulated
+    attr_reader :expiration_month
+    attr_reader :expiration_year
+    attr_reader :healthcare
+    attr_reader :image_url
+    attr_reader :issuing_bank
+    attr_reader :last_4
+    attr_reader :payroll
+    attr_reader :prepaid
+    attr_reader :product_id
+    attr_reader :subscriptions
+    attr_reader :token
+    attr_reader :unique_number_identifier
+    attr_reader :updated_at
+    attr_reader :verification
 
     def initialize(gateway, attributes) # :nodoc:
       @gateway = gateway

--- a/lib/braintree/merchant.rb
+++ b/lib/braintree/merchant.rb
@@ -2,7 +2,14 @@ module Braintree
   class Merchant
     include BaseModule # :nodoc:
 
-    attr_reader :id, :email, :company_name, :country_code_alpha2, :country_code_alpha3, :country_code_numeric, :country_name, :merchant_accounts
+    attr_reader :company_name
+    attr_reader :country_code_alpha2
+    attr_reader :country_code_alpha3
+    attr_reader :country_code_numeric
+    attr_reader :country_name
+    attr_reader :email
+    attr_reader :id
+    attr_reader :merchant_accounts
 
     def initialize(gateway, attributes) # :nodoc:
       @merchant_accounts = attributes.delete(:merchant_accounts).map do |merchant_account|

--- a/lib/braintree/merchant_account.rb
+++ b/lib/braintree/merchant_account.rb
@@ -18,9 +18,14 @@ module Braintree
       include Braintree::MerchantAccount::FundingDestination
     end
 
-    attr_reader :status, :id, :master_merchant_account,
-      :individual_details, :business_details, :funding_details,
-      :currency_iso_code, :default
+    attr_reader :business_details
+    attr_reader :currency_iso_code
+    attr_reader :default
+    attr_reader :funding_details
+    attr_reader :id
+    attr_reader :individual_details
+    attr_reader :master_merchant_account
+    attr_reader :status
 
     alias_method :default?, :default
 

--- a/lib/braintree/merchant_account/funding_details.rb
+++ b/lib/braintree/merchant_account/funding_details.rb
@@ -3,7 +3,12 @@ module Braintree
     class FundingDetails
       include BaseModule
 
-      attr_reader :account_number_last_4, :destination, :email, :mobile_phone, :routing_number, :descriptor
+      attr_reader :account_number_last_4
+      attr_reader :descriptor
+      attr_reader :destination
+      attr_reader :email
+      attr_reader :mobile_phone
+      attr_reader :routing_number
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/merchant_account/individual_details.rb
+++ b/lib/braintree/merchant_account/individual_details.rb
@@ -3,8 +3,13 @@ module Braintree
     class IndividualDetails
       include BaseModule
 
-      attr_reader :first_name, :last_name, :email, :phone, :date_of_birth, :ssn_last_4,
-        :address_details
+      attr_reader :address_details
+      attr_reader :date_of_birth
+      attr_reader :email
+      attr_reader :first_name
+      attr_reader :last_name
+      attr_reader :phone
+      attr_reader :ssn_last_4
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/paypal_account.rb
+++ b/lib/braintree/paypal_account.rb
@@ -2,7 +2,14 @@ module Braintree
   class PayPalAccount
     include BaseModule
 
-    attr_reader :email, :token, :image_url, :created_at, :updated_at, :subscriptions, :billing_agreement_id, :customer_id
+    attr_reader :billing_agreement_id
+    attr_reader :created_at
+    attr_reader :customer_id
+    attr_reader :email
+    attr_reader :image_url
+    attr_reader :subscriptions
+    attr_reader :token
+    attr_reader :updated_at
 
     def initialize(gateway, attributes) # :nodoc:
       @gateway = gateway

--- a/lib/braintree/plan.rb
+++ b/lib/braintree/plan.rb
@@ -2,22 +2,22 @@ module Braintree
   class Plan
     include BaseModule
 
-    attr_reader :id
-    attr_reader :merchant_id
+    attr_reader :add_ons
     attr_reader :billing_day_of_month
     attr_reader :billing_frequency
+    attr_reader :created_at
     attr_reader :currency_iso_code
     attr_reader :description
     attr_reader :discounts
+    attr_reader :id
+    attr_reader :merchant_id
     attr_reader :name
     attr_reader :number_of_billing_cycles
     attr_reader :price
     attr_reader :trial_duration
     attr_reader :trial_duration_unit
     attr_reader :trial_period
-    attr_reader :created_at
     attr_reader :updated_at
-    attr_reader :add_ons
 
     def self.all
       Configuration.gateway.plan.all

--- a/lib/braintree/settlement_batch_summary.rb
+++ b/lib/braintree/settlement_batch_summary.rb
@@ -1,6 +1,7 @@
 module Braintree
   class SettlementBatchSummary
     include BaseModule
+    
     attr_reader :records
 
     def self.generate(settlement_date, group_by_custom_field = nil)

--- a/lib/braintree/subscription.rb
+++ b/lib/braintree/subscription.rb
@@ -24,20 +24,35 @@ module Braintree
       Month = "month"
     end
 
-    attr_reader :days_past_due, :price, :plan_id, :id, :status, :payment_method_token, :merchant_account_id
-    attr_reader :first_billing_date, :next_billing_date, :billing_period_start_date, :billing_period_end_date
-    attr_reader :paid_through_date, :balance
-    attr_reader :trial_period, :trial_duration, :trial_duration_unit
-    attr_reader :failure_count
-    attr_reader :transactions
-    attr_reader :next_billing_period_amount
-    attr_reader :number_of_billing_cycles, :billing_day_of_month
-    attr_reader :add_ons, :discounts
-    attr_reader :descriptor
-    attr_reader :description
+    attr_reader :add_ons
+    attr_reader :balance
+    attr_reader :billing_day_of_month
+    attr_reader :billing_period_end_date
+    attr_reader :billing_period_start_date
+    attr_reader :created_at
     attr_reader :current_billing_cycle
-    attr_reader :updated_at, :created_at
+    attr_reader :days_past_due
+    attr_reader :description
+    attr_reader :descriptor
+    attr_reader :discounts
+    attr_reader :failure_count
+    attr_reader :first_billing_date
+    attr_reader :id
+    attr_reader :merchant_account_id
+    attr_reader :next_billing_date
+    attr_reader :next_billing_period_amount
+    attr_reader :number_of_billing_cycles
+    attr_reader :paid_through_date
+    attr_reader :payment_method_token
+    attr_reader :plan_id
+    attr_reader :price
+    attr_reader :status
     attr_reader :status_history
+    attr_reader :transactions
+    attr_reader :trial_duration
+    attr_reader :trial_duration_unit
+    attr_reader :trial_period
+    attr_reader :updated_at
 
     def self.cancel(subscription_id)
       Configuration.gateway.subscription.cancel(subscription_id)

--- a/lib/braintree/subscription/status_details.rb
+++ b/lib/braintree/subscription/status_details.rb
@@ -3,7 +3,14 @@ module Braintree
     class StatusDetails # :nodoc:
       include BaseModule
 
-      attr_reader :balance, :price, :status, :subscription_source, :timestamp, :user, :currency_iso_code, :plan_id
+      attr_reader :balance
+      attr_reader :price
+      attr_reader :status
+      attr_reader :subscription_source
+      attr_reader :timestamp
+      attr_reader :user
+      attr_reader :currency_iso_code
+      attr_reader :plan_id
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/successful_result.rb
+++ b/lib/braintree/successful_result.rb
@@ -2,7 +2,25 @@ module Braintree
   class SuccessfulResult
     include BaseModule
 
-    attr_reader :address, :credit_card, :customer, :document_upload, :merchant_account, :payment_method, :settlement_batch_summary, :subscription, :new_transaction, :transaction, :payment_method_nonce, :credentials, :merchant, :supported_networks, :paypal_account, :merchant_accounts, :disputes, :evidence, :apple_pay_options
+    attr_reader :address
+    attr_reader :apple_pay_options
+    attr_reader :credentials
+    attr_reader :credit_card
+    attr_reader :customer
+    attr_reader :disputes
+    attr_reader :document_upload
+    attr_reader :evidence
+    attr_reader :merchant
+    attr_reader :merchant_account
+    attr_reader :merchant_accounts
+    attr_reader :new_transaction
+    attr_reader :payment_method
+    attr_reader :payment_method_nonce
+    attr_reader :paypal_account
+    attr_reader :settlement_batch_summary
+    attr_reader :subscription
+    attr_reader :supported_networks
+    attr_reader :transaction
 
     def initialize(attributes = {}) # :nodoc:
       @attrs = attributes.keys

--- a/lib/braintree/transaction.rb
+++ b/lib/braintree/transaction.rb
@@ -68,69 +68,70 @@ module Braintree
       All = constants.map { |c| const_get(c) }
     end
 
-    attr_reader :avs_error_response_code, :avs_postal_code_response_code, :avs_street_address_response_code
-    attr_reader :amount, :created_at, :credit_card_details, :customer_details, :subscription_details, :service_fee_amount, :id
+    attr_reader :add_ons
+    attr_reader :additional_processor_response          # The raw response from the processor.
+    attr_reader :amex_express_checkout_details
+    attr_reader :amount
+    attr_reader :android_pay_details
+    attr_reader :apple_pay_details
+    attr_reader :authorization_adjustments
+    attr_reader :authorized_transaction_id
+    attr_reader :avs_error_response_code
+    attr_reader :avs_postal_code_response_code
+    attr_reader :avs_street_address_response_code
+    attr_reader :billing_details, :shipping_details
+    attr_reader :channel
+    attr_reader :coinbase_details
+    attr_reader :created_at
+    attr_reader :credit_card_details
     attr_reader :currency_iso_code
     attr_reader :custom_fields
+    attr_reader :customer_details
     attr_reader :cvv_response_code
-    attr_reader :disbursement_details
-    attr_reader :disputes
     attr_reader :descriptor
+    attr_reader :disbursement_details
+    attr_reader :discount_amount
+    attr_reader :discounts
+    attr_reader :disputes
     attr_reader :escrow_status
+    attr_reader :facilitated_details
+    attr_reader :facilitator_details
     attr_reader :gateway_rejection_reason
+    attr_reader :id
+    attr_reader :ideal_payment_details
+    attr_reader :masterpass_card_details
     attr_reader :merchant_account_id
     attr_reader :order_id
-    attr_reader :channel
-    attr_reader :billing_details, :shipping_details
+    attr_reader :partial_settlement_transaction_ids
+    attr_reader :payment_instrument_type
     attr_reader :paypal_details
-    attr_reader :apple_pay_details
-    attr_reader :android_pay_details
-    attr_reader :amex_express_checkout_details
-    attr_reader :venmo_account_details
-    attr_reader :coinbase_details
     attr_reader :plan_id
-    # The authorization code from the processor.
-    attr_reader :processor_authorization_code
-    # The response code from the processor.
-    attr_reader :processor_response_code
-    # The response text from the processor.
-    attr_reader :processor_response_text
-    # The raw response from the processor.
-    attr_reader :additional_processor_response
-    # The settlement response code from the processor.
-    attr_reader :processor_settlement_response_code
-    # The settlement response text from the processor.
-    attr_reader :processor_settlement_response_text
-    attr_reader :voice_referral_number
+    attr_reader :processor_authorization_code           # Authorization code from the processor.
+    attr_reader :processor_response_code                # Response code from the processor.
+    attr_reader :processor_response_text                # Response text from the processor.
+    attr_reader :processor_settlement_response_code     # Settlement response code from the processor.
+    attr_reader :processor_settlement_response_text     # Settlement response text from the processor.
     attr_reader :purchase_order_number
     attr_reader :recurring
     attr_reader :refund_ids, :refunded_transaction_id
+    attr_reader :risk_data
+    attr_reader :service_fee_amount
     attr_reader :settlement_batch_id
-    attr_reader :authorized_transaction_id
-    attr_reader :partial_settlement_transaction_ids
-    # See Transaction::Status
-    attr_reader :status
+    attr_reader :shipping_amount
+    attr_reader :ships_from_postal_code
+    attr_reader :status                                 # See Transaction::Status
     attr_reader :status_history
+    attr_reader :subscription_details
     attr_reader :subscription_id
     attr_reader :tax_amount
     attr_reader :tax_exempt
-    attr_reader :shipping_amount
-    attr_reader :discount_amount
-    attr_reader :ships_from_postal_code
-    # Will either be "sale" or "credit"
-    attr_reader :type
-    attr_reader :updated_at
-    attr_reader :add_ons, :discounts
-    attr_reader :payment_instrument_type
-    attr_reader :risk_data
-    attr_reader :facilitated_details
-    attr_reader :facilitator_details
     attr_reader :three_d_secure_info
+    attr_reader :type                                   # Will either be "sale" or "credit"
+    attr_reader :updated_at
     attr_reader :us_bank_account_details
-    attr_reader :ideal_payment_details
+    attr_reader :venmo_account_details
     attr_reader :visa_checkout_card_details
-    attr_reader :masterpass_card_details
-    attr_reader :authorization_adjustments
+    attr_reader :voice_referral_number
 
     def self.create(attributes)
       Configuration.gateway.transaction.create(attributes)

--- a/lib/braintree/transaction/address_details.rb
+++ b/lib/braintree/transaction/address_details.rb
@@ -3,10 +3,19 @@ module Braintree
     class AddressDetails # :nodoc:
       include BaseModule
 
-      attr_reader :id, :first_name, :last_name, :company,
-        :street_address, :extended_address, :locality, :region,
-        :postal_code, :country_code_alpha2, :country_code_alpha3,
-        :country_code_numeric, :country_name
+      attr_reader :company
+      attr_reader :country_code_alpha2
+      attr_reader :country_code_alpha3
+      attr_reader :country_code_numeric
+      attr_reader :country_name
+      attr_reader :extended_address
+      attr_reader :first_name
+      attr_reader :id
+      attr_reader :last_name
+      attr_reader :locality
+      attr_reader :postal_code
+      attr_reader :region
+      attr_reader :street_address
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/transaction/amex_express_checkout_details.rb
+++ b/lib/braintree/transaction/amex_express_checkout_details.rb
@@ -3,8 +3,15 @@ module Braintree
     class AmexExpressCheckoutDetails
       include BaseModule
 
-      attr_reader :card_type, :token, :bin, :expiration_month, :expiration_year,
-        :card_member_number, :card_member_expiry_date, :image_url, :source_description
+      attr_reader :bin
+      attr_reader :card_member_expiry_date
+      attr_reader :card_member_number
+      attr_reader :card_type
+      attr_reader :expiration_month
+      attr_reader :expiration_year
+      attr_reader :image_url
+      attr_reader :source_description
+      attr_reader :token
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/transaction/android_pay_details.rb
+++ b/lib/braintree/transaction/android_pay_details.rb
@@ -3,9 +3,16 @@ module Braintree
     class AndroidPayDetails
       include BaseModule
 
-      attr_reader :card_type, :last_4, :expiration_month, :expiration_year,
-        :google_transaction_id, :virtual_card_type, :virtual_card_last_4,
-        :source_card_type, :source_card_last_4, :source_description
+      attr_reader :card_type
+      attr_reader :expiration_month
+      attr_reader :expiration_year
+      attr_reader :google_transaction_id
+      attr_reader :last_4
+      attr_reader :source_card_last_4
+      attr_reader :source_card_type
+      attr_reader :source_description
+      attr_reader :virtual_card_last_4
+      attr_reader :virtual_card_type
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/transaction/credit_card_details.rb
+++ b/lib/braintree/transaction/credit_card_details.rb
@@ -3,10 +3,25 @@ module Braintree
     class CreditCardDetails # :nodoc:
       include BaseModule
 
-      attr_reader :bin, :card_type, :cardholder_name, :commercial, :country_of_issuance,
-        :customer_location, :debit, :durbin_regulated, :expiration_month, :expiration_year,
-        :healthcare, :image_url, :issuing_bank, :last_4, :payroll, :prepaid, :product_id,
-        :token, :unique_number_identifier
+      attr_reader :bin
+      attr_reader :card_type
+      attr_reader :cardholder_name
+      attr_reader :commercial
+      attr_reader :country_of_issuance
+      attr_reader :customer_location
+      attr_reader :debit
+      attr_reader :durbin_regulated
+      attr_reader :expiration_month
+      attr_reader :expiration_year
+      attr_reader :healthcare
+      attr_reader :image_url
+      attr_reader :issuing_bank
+      attr_reader :last_4
+      attr_reader :payroll
+      attr_reader :prepaid
+      attr_reader :product_id
+      attr_reader :token
+      attr_reader :unique_number_identifier
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?
@@ -17,8 +32,27 @@ module Braintree
       end
 
       def inspect
-        attr_order = [:token, :bin, :last_4, :card_type, :expiration_date, :cardholder_name, :customer_location, :prepaid,
-        :healthcare, :durbin_regulated, :debit, :commercial, :payroll, :product_id, :country_of_issuance, :issuing_bank, :image_url, :unique_number_identifier]
+        attr_order = [
+          :token,
+          :bin,
+          :last_4,
+          :card_type,
+          :expiration_date,
+          :cardholder_name,
+          :customer_location,
+          :prepaid,
+          :healthcare,
+          :durbin_regulated,
+          :debit,
+          :commercial,
+          :payroll,
+          :product_id,
+          :country_of_issuance,
+          :issuing_bank,
+          :image_url,
+          :unique_number_identifier
+        ]
+
         formatted_attrs = attr_order.map do |attr|
           "#{attr}: #{send(attr).inspect}"
         end

--- a/lib/braintree/transaction/disbursement_details.rb
+++ b/lib/braintree/transaction/disbursement_details.rb
@@ -3,7 +3,11 @@ module Braintree
     class DisbursementDetails # :nodoc:
       include BaseModule
 
-      attr_reader :disbursement_date, :settlement_amount, :settlement_currency_iso_code, :settlement_currency_exchange_rate, :success
+      attr_reader :disbursement_date
+      attr_reader :settlement_amount
+      attr_reader :settlement_currency_exchange_rate
+      attr_reader :settlement_currency_iso_code
+      attr_reader :success
 
       alias_method :success?, :success
 

--- a/lib/braintree/transaction/masterpass_card_details.rb
+++ b/lib/braintree/transaction/masterpass_card_details.rb
@@ -3,10 +3,24 @@ module Braintree
     class MasterpassCardDetails # :nodoc:
       include BaseModule
 
-      attr_reader :bin, :card_type, :cardholder_name, :commercial, :country_of_issuance,
-        :customer_location, :debit, :durbin_regulated, :expiration_month, :expiration_year,
-        :healthcare, :image_url, :issuing_bank, :last_4, :payroll, :prepaid, :product_id,
-        :token
+      attr_reader :bin
+      attr_reader :card_type
+      attr_reader :cardholder_name
+      attr_reader :commercial
+      attr_reader :country_of_issuance
+      attr_reader :customer_location
+      attr_reader :debit
+      attr_reader :durbin_regulated
+      attr_reader :expiration_month
+      attr_reader :expiration_year
+      attr_reader :healthcare
+      attr_reader :image_url
+      attr_reader :issuing_bank
+      attr_reader :last_4
+      attr_reader :payroll
+      attr_reader :prepaid
+      attr_reader :product_id
+      attr_reader :token
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/transaction/paypal_details.rb
+++ b/lib/braintree/transaction/paypal_details.rb
@@ -3,10 +3,24 @@ module Braintree
     class PayPalDetails
       include BaseModule
 
-      attr_reader :custom_field, :payer_email, :payment_id, :authorization_id, :token,
-        :image_url, :debug_id, :payee_email, :payer_id, :payer_first_name, :payer_last_name,
-        :payer_status, :seller_protection_status, :capture_id, :refund_id, :transaction_fee_amount,
-        :transaction_fee_currency_iso_code, :description
+      attr_reader :authorization_id
+      attr_reader :capture_id
+      attr_reader :custom_field
+      attr_reader :debug_id
+      attr_reader :description
+      attr_reader :image_url
+      attr_reader :payee_email
+      attr_reader :payer_email
+      attr_reader :payer_first_name
+      attr_reader :payer_id
+      attr_reader :payer_last_name
+      attr_reader :payer_status
+      attr_reader :payment_id
+      attr_reader :refund_id
+      attr_reader :seller_protection_status
+      attr_reader :token
+      attr_reader :transaction_fee_amount
+      attr_reader :transaction_fee_currency_iso_code
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/transaction/us_bank_account_details.rb
+++ b/lib/braintree/transaction/us_bank_account_details.rb
@@ -3,7 +3,14 @@ module Braintree
     class UsBankAccountDetails # :nodoc:
       include BaseModule
 
-      attr_reader :routing_number, :last_4, :account_type, :account_holder_name, :token, :image_url, :bank_name, :ach_mandate
+      attr_reader :account_holder_name
+      attr_reader :account_type
+      attr_reader :ach_mandate
+      attr_reader :bank_name
+      attr_reader :image_url
+      attr_reader :last_4
+      attr_reader :routing_number
+      attr_reader :token
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/transaction/visa_checkout_card_details.rb
+++ b/lib/braintree/transaction/visa_checkout_card_details.rb
@@ -3,10 +3,25 @@ module Braintree
     class VisaCheckoutCardDetails # :nodoc:
       include BaseModule
 
-      attr_reader :bin, :card_type, :cardholder_name, :commercial, :country_of_issuance,
-        :customer_location, :debit, :durbin_regulated, :expiration_month, :expiration_year,
-        :healthcare, :image_url, :issuing_bank, :last_4, :payroll, :prepaid, :product_id,
-        :token, :call_id
+      attr_reader :bin
+      attr_reader :call_id
+      attr_reader :card_type
+      attr_reader :cardholder_name
+      attr_reader :commercial
+      attr_reader :country_of_issuance
+      attr_reader :customer_location
+      attr_reader :debit
+      attr_reader :durbin_regulated
+      attr_reader :expiration_month
+      attr_reader :expiration_year
+      attr_reader :healthcare
+      attr_reader :image_url
+      attr_reader :issuing_bank
+      attr_reader :last_4
+      attr_reader :payroll
+      attr_reader :prepaid
+      attr_reader :product_id
+      attr_reader :token
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/lib/braintree/us_bank_account.rb
+++ b/lib/braintree/us_bank_account.rb
@@ -2,7 +2,15 @@ module Braintree
   class UsBankAccount
     include BaseModule
 
-    attr_reader :routing_number, :last_4, :account_type, :account_holder_name, :token, :image_url, :bank_name, :ach_mandate, :default
+    attr_reader :account_holder_name
+    attr_reader :account_type
+    attr_reader :ach_mandate
+    attr_reader :bank_name
+    attr_reader :default
+    attr_reader :image_url
+    attr_reader :last_4
+    attr_reader :routing_number
+    attr_reader :token
 
     def initialize(gateway, attributes) # :nodoc:
       @gateway = gateway

--- a/lib/braintree/venmo_account.rb
+++ b/lib/braintree/venmo_account.rb
@@ -2,8 +2,16 @@ module Braintree
   class VenmoAccount
     include BaseModule # :nodoc:
 
-    attr_reader :customer_id, :username, :venmo_user_id, :token, :source_description, :subscriptions,
-      :image_url, :default, :updated_at, :created_at
+    attr_reader :created_at
+    attr_reader :customer_id
+    attr_reader :default
+    attr_reader :image_url
+    attr_reader :source_description
+    attr_reader :subscriptions
+    attr_reader :token
+    attr_reader :updated_at
+    attr_reader :username
+    attr_reader :venmo_user_id
 
     def initialize(gateway, attributes) # :nodoc:
       @gateway = gateway
@@ -24,4 +32,3 @@ module Braintree
     end
   end
 end
-

--- a/lib/braintree/visa_checkout_card.rb
+++ b/lib/braintree/visa_checkout_card.rb
@@ -2,12 +2,32 @@ module Braintree
   class VisaCheckoutCard
     include BaseModule # :nodoc:
 
-    attr_reader :billing_address, :bin, :card_type, :cardholder_name,
-      :commercial, :country_of_issuance, :created_at, :customer_id,
-      :customer_location, :debit, :durbin_regulated, :expiration_month,
-      :expiration_year, :healthcare, :issuing_bank, :last_4, :payroll,
-      :prepaid, :product_id, :subscriptions, :token, :unique_number_identifier,
-      :updated_at, :image_url, :verification, :call_id
+    attr_reader :billing_address
+    attr_reader :bin
+    attr_reader :call_id
+    attr_reader :card_type
+    attr_reader :cardholder_name
+    attr_reader :commercial
+    attr_reader :country_of_issuance
+    attr_reader :created_at
+    attr_reader :customer_id
+    attr_reader :customer_location
+    attr_reader :debit
+    attr_reader :durbin_regulated
+    attr_reader :expiration_month
+    attr_reader :expiration_year
+    attr_reader :healthcare
+    attr_reader :image_url
+    attr_reader :issuing_bank
+    attr_reader :last_4
+    attr_reader :payroll
+    attr_reader :prepaid
+    attr_reader :product_id
+    attr_reader :subscriptions
+    attr_reader :token
+    attr_reader :unique_number_identifier
+    attr_reader :updated_at
+    attr_reader :verification
 
     def initialize(gateway, attributes) # :nodoc:
       @gateway = gateway

--- a/lib/braintree/webhook_notification.rb
+++ b/lib/braintree/webhook_notification.rb
@@ -42,18 +42,18 @@ module Braintree
       GrantedPaymentInstrumentUpdate = "granted_payment_instrument_update"
     end
 
-    attr_reader :subscription
-    attr_reader :kind
-    attr_reader :timestamp
-    attr_reader :transaction
-    attr_reader :partner_merchant
+    attr_reader :account_updater_daily_report
+    attr_reader :connected_merchant_paypal_status_changed
+    attr_reader :connected_merchant_status_transitioned
     attr_reader :disbursement
     attr_reader :dispute
-    attr_reader :account_updater_daily_report
-    attr_reader :ideal_payment
-    attr_reader :connected_merchant_status_transitioned
-    attr_reader :connected_merchant_paypal_status_changed
     attr_reader :granted_payment_instrument_update
+    attr_reader :ideal_payment
+    attr_reader :kind
+    attr_reader :partner_merchant
+    attr_reader :subscription
+    attr_reader :timestamp
+    attr_reader :transaction
 
     def self.parse(signature, payload)
       Configuration.gateway.webhook_notification.parse(signature, payload)


### PR DESCRIPTION
# Summary

Reading through the code, there are many very clear patterns and practices that are consistent across the repository.  Which is awesome!  I just noticed the `attr_reader` declarations are about 90% consistent with this pattern (`attr_reader :one, :two, ...`), and I just wanted to clear it up so the whole repository matches.

### Please let me know if this is helpful or not

Some open source software is particular about anything that could be considered _cosmetic_.  I, personally, appreciate whenever someone comes back and cleans up inconsistencies with stylings.  But that's me.

## Note:

I initially ignored `transaction.rb` because it is one of the main models in the repository and also has a few comments sprinkled inside the many `attr_reader` lines.  I can definitely clean that up too, if helpful, and leave comments in a separate line.  I was thinking something like this:

```ruby
attr_reader :one, :two, :three, :four, :five, :six,
  :seven, :eight, # ...
  # ...
attr_reader :status    # See Transaction::Status
attr_reader :type      # Either 'sale' or 'credit' 
```

# Checklist

- [x] Ran unit tests (`rake test:unit`)
