### PR TITLE
Update BigDecimal call

### DIFF
--- a/lib/braintree/util.rb
+++ b/lib/braintree/util.rb
@@ -102,7 +102,7 @@ module Braintree
       when BigDecimal, NilClass
         decimal
       when String
-        BigDecimal.new(decimal)
+        BigDecimal(decimal)
       else
         raise ArgumentError, "Argument must be a String or BigDecimal"
       end


### PR DESCRIPTION
BigDecimal.new is now deprecated.

This updates a call to `.new` to use the new, preferred method syntax.
