### PR TITLE
use Kernel#BigDecimal instead of BigDecimal#new

### DIFF
--- a/lib/braintree/util.rb
+++ b/lib/braintree/util.rb
@@ -102,7 +102,7 @@ module Braintree
       when BigDecimal, NilClass
         decimal
       when String
-        BigDecimal.new(decimal)
+        BigDecimal(decimal)
       else
         raise ArgumentError, "Argument must be a String or BigDecimal"
       end

--- a/spec/integration/braintree/add_on_spec.rb
+++ b/spec/integration/braintree/add_on_spec.rb
@@ -21,7 +21,7 @@ describe Braintree::AddOn do
       add_on = add_ons.select { |add_on| add_on.id == id }.first
 
       add_on.should_not be_nil
-      add_on.amount.should == BigDecimal.new(expected[:amount])
+      add_on.amount.should == BigDecimal(expected[:amount])
       add_on.created_at.should_not be_nil
       add_on.description.should == expected[:description]
       add_on.kind.should == expected[:kind]

--- a/spec/integration/braintree/credit_card_spec.rb
+++ b/spec/integration/braintree/credit_card_spec.rb
@@ -592,7 +592,7 @@ describe Braintree::CreditCard do
         :amount => "100.00"
       )
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "credit"
       result.transaction.customer_details.id.should == customer.id
       result.transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -614,7 +614,7 @@ describe Braintree::CreditCard do
         customer.credit_cards[0].token,
         :amount => "100.00"
       )
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.type.should == "credit"
       transaction.customer_details.id.should == customer.id
       transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -1064,7 +1064,7 @@ describe Braintree::CreditCard do
         :amount => "100.00"
       )
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "credit"
       result.transaction.customer_details.id.should == customer.id
       result.transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -1083,7 +1083,7 @@ describe Braintree::CreditCard do
         }
       )
       transaction = customer.credit_cards[0].credit!(:amount => "100.00")
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.type.should == "credit"
       transaction.customer_details.id.should == customer.id
       transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -1208,7 +1208,7 @@ describe Braintree::CreditCard do
       found_card.subscriptions.first.id.should == subscription.id
       found_card.subscriptions.first.plan_id.should == "integration_trialless_plan"
       found_card.subscriptions.first.payment_method_token.should == credit_card.token
-      found_card.subscriptions.first.price.should == BigDecimal.new("1.00")
+      found_card.subscriptions.first.price.should == BigDecimal("1.00")
     end
 
     it "raises a NotFoundError exception if payment method cannot be found" do
@@ -1295,7 +1295,7 @@ describe Braintree::CreditCard do
       result = Braintree::CreditCard.sale(customer.credit_cards[0].token, :amount => "100.00")
 
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "sale"
       result.transaction.customer_details.id.should == customer.id
       result.transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -1319,7 +1319,7 @@ describe Braintree::CreditCard do
       )
 
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "sale"
       result.transaction.customer_details.id.should == customer.id
       result.transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -1336,7 +1336,7 @@ describe Braintree::CreditCard do
         }
       )
       transaction = Braintree::CreditCard.sale!(customer.credit_cards[0].token, :amount => "100.00")
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.type.should == "sale"
       transaction.customer_details.id.should == customer.id
       transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -1358,7 +1358,7 @@ describe Braintree::CreditCard do
         :amount => "100.00"
       )
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "sale"
       result.transaction.customer_details.id.should == customer.id
       result.transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -1377,7 +1377,7 @@ describe Braintree::CreditCard do
         }
       )
       transaction = customer.credit_cards[0].sale!(:amount => "100.00")
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.type.should == "sale"
       transaction.customer_details.id.should == customer.id
       transaction.credit_card_details.token.should == customer.credit_cards[0].token

--- a/spec/integration/braintree/customer_spec.rb
+++ b/spec/integration/braintree/customer_spec.rb
@@ -531,7 +531,7 @@ describe Braintree::Customer do
       )
       result = Braintree::Customer.credit(customer.id, :amount => "100.00")
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "credit"
       result.transaction.customer_details.id.should == customer.id
       result.transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -550,7 +550,7 @@ describe Braintree::Customer do
         }
       )
       transaction = Braintree::Customer.credit!(customer.id, :amount => "100.00")
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.type.should == "credit"
       transaction.customer_details.id.should == customer.id
       transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -570,7 +570,7 @@ describe Braintree::Customer do
       )
       result = Braintree::Customer.sale(customer.id, :amount => "100.00")
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "sale"
       result.transaction.customer_details.id.should == customer.id
       result.transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -589,7 +589,7 @@ describe Braintree::Customer do
         }
       )
       transaction = Braintree::Customer.sale!(customer.id, :amount => "100.00")
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.type.should == "sale"
       transaction.customer_details.id.should == customer.id
       transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -626,7 +626,7 @@ describe Braintree::Customer do
         :amount => "100.00"
       )
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "sale"
       result.transaction.customer_details.id.should == customer.id
       result.transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -645,7 +645,7 @@ describe Braintree::Customer do
         }
       )
       transaction = customer.sale!(:amount => "100.00")
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.type.should == "sale"
       transaction.customer_details.id.should == customer.id
       transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -681,7 +681,7 @@ describe Braintree::Customer do
         :amount => "100.00"
       )
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "credit"
       result.transaction.customer_details.id.should == customer.id
       result.transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -700,7 +700,7 @@ describe Braintree::Customer do
         }
       )
       transaction = customer.credit!(:amount => "100.00")
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.type.should == "credit"
       transaction.customer_details.id.should == customer.id
       transaction.credit_card_details.token.should == customer.credit_cards[0].token
@@ -820,7 +820,7 @@ describe Braintree::Customer do
       found_customer.credit_cards.first.subscriptions.first.id.should == subscription.id
       found_customer.credit_cards.first.subscriptions.first.plan_id.should == "integration_trialless_plan"
       found_customer.credit_cards.first.subscriptions.first.payment_method_token.should == credit_card.token
-      found_customer.credit_cards.first.subscriptions.first.price.should == BigDecimal.new("1.00")
+      found_customer.credit_cards.first.subscriptions.first.price.should == BigDecimal("1.00")
     end
 
     context "when given an association filter id" do

--- a/spec/integration/braintree/discount_spec.rb
+++ b/spec/integration/braintree/discount_spec.rb
@@ -21,7 +21,7 @@ describe Braintree::Discount do
       discount = discounts.select { |discount| discount.id == id }.first
 
       discount.should_not be_nil
-      discount.amount.should == BigDecimal.new(expected[:amount])
+      discount.amount.should == BigDecimal(expected[:amount])
       discount.created_at.should_not be_nil
       discount.description.should == expected[:description]
       discount.kind.should == expected[:kind]

--- a/spec/integration/braintree/ideal_payment_spec.rb
+++ b/spec/integration/braintree/ideal_payment_spec.rb
@@ -14,7 +14,7 @@ describe Braintree::IdealPayment do
       )
 
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      result.transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       result.transaction.type.should == "sale"
       ideal_payment_details = result.transaction.ideal_payment_details
       ideal_payment_details.ideal_payment_id.should =~ /^idealpayment_\w{6,}$/
@@ -36,7 +36,7 @@ describe Braintree::IdealPayment do
         :amount => Braintree::Test::TransactionAmounts::Authorize
       )
 
-      transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       transaction.type.should == "sale"
       ideal_payment_details = transaction.ideal_payment_details
       ideal_payment_details.ideal_payment_id.should =~ /^idealpayment_\w{6,}$/

--- a/spec/integration/braintree/payment_method_spec.rb
+++ b/spec/integration/braintree/payment_method_spec.rb
@@ -295,7 +295,7 @@ describe Braintree::PaymentMethod do
       result.credit_card_verification.status.should == Braintree::Transaction::Status::ProcessorDeclined
       result.credit_card_verification.processor_response_code.should == "2000"
       result.credit_card_verification.processor_response_text.should == "Do Not Honor"
-      result.credit_card_verification.amount.should == BigDecimal.new("100.00")
+      result.credit_card_verification.amount.should == BigDecimal("100.00")
     end
 
     it "respects fail_on_duplicate_payment_method when included outside of the nonce" do
@@ -759,7 +759,7 @@ describe Braintree::PaymentMethod do
         found_card.subscriptions.first.id.should == subscription.id
         found_card.subscriptions.first.plan_id.should == "integration_trialless_plan"
         found_card.subscriptions.first.payment_method_token.should == credit_card.token
-        found_card.subscriptions.first.price.should == BigDecimal.new("1.00")
+        found_card.subscriptions.first.price.should == BigDecimal("1.00")
       end
     end
 

--- a/spec/integration/braintree/paypal_account_spec.rb
+++ b/spec/integration/braintree/paypal_account_spec.rb
@@ -272,7 +272,7 @@ describe Braintree::PayPalAccount do
       result = Braintree::PayPalAccount.sale(customer.paypal_accounts[0].token, :amount => "100.00")
 
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "sale"
       result.transaction.customer_details.id.should == customer.id
       result.transaction.paypal_details.token.should == customer.paypal_accounts[0].token
@@ -287,7 +287,7 @@ describe Braintree::PayPalAccount do
 
       transaction = Braintree::PayPalAccount.sale!(customer.paypal_accounts[0].token, :amount => "100.00")
 
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.type.should == "sale"
       transaction.customer_details.id.should == customer.id
       transaction.paypal_details.token.should == customer.paypal_accounts[0].token

--- a/spec/integration/braintree/subscription_spec.rb
+++ b/spec/integration/braintree/subscription_spec.rb
@@ -359,7 +359,7 @@ describe Braintree::Subscription do
             :price => 98.76
           )
 
-          result.subscription.price.should == BigDecimal.new("98.76")
+          result.subscription.price.should == BigDecimal("98.76")
         end
       end
     end
@@ -445,14 +445,14 @@ describe Braintree::Subscription do
         add_ons = subscription.add_ons.sort_by { |add_on| add_on.id }
 
         add_ons.first.id.should == "increase_10"
-        add_ons.first.amount.should == BigDecimal.new("10.00")
+        add_ons.first.amount.should == BigDecimal("10.00")
         add_ons.first.quantity.should == 1
         add_ons.first.number_of_billing_cycles.should be_nil
         add_ons.first.never_expires?.should be(true)
         add_ons.first.current_billing_cycle.should == 0
 
         add_ons.last.id.should == "increase_20"
-        add_ons.last.amount.should == BigDecimal.new("20.00")
+        add_ons.last.amount.should == BigDecimal("20.00")
         add_ons.last.quantity.should == 1
         add_ons.last.number_of_billing_cycles.should be_nil
         add_ons.last.never_expires?.should be(true)
@@ -462,14 +462,14 @@ describe Braintree::Subscription do
         discounts = subscription.discounts.sort_by { |discount| discount.id }
 
         discounts.first.id.should == "discount_11"
-        discounts.first.amount.should == BigDecimal.new("11.00")
+        discounts.first.amount.should == BigDecimal("11.00")
         discounts.first.quantity.should == 1
         discounts.first.number_of_billing_cycles.should be_nil
         discounts.first.never_expires?.should be(true)
         discounts.first.current_billing_cycle.should == 0
 
         discounts.last.id.should == "discount_7"
-        discounts.last.amount.should == BigDecimal.new("7.00")
+        discounts.last.amount.should == BigDecimal("7.00")
         discounts.last.quantity.should == 1
         discounts.last.number_of_billing_cycles.should be_nil
         discounts.last.never_expires?.should be(true)
@@ -483,7 +483,7 @@ describe Braintree::Subscription do
           :add_ons => {
             :update => [
               {
-                :amount => BigDecimal.new("50.00"),
+                :amount => BigDecimal("50.00"),
                 :existing_id => SpecHelper::AddOnIncrease10,
                 :quantity => 2,
                 :number_of_billing_cycles => 5
@@ -493,7 +493,7 @@ describe Braintree::Subscription do
           :discounts => {
             :update => [
               {
-                :amount => BigDecimal.new("15.00"),
+                :amount => BigDecimal("15.00"),
                 :existing_id => SpecHelper::Discount7,
                 :quantity => 3,
                 :never_expires => true
@@ -509,14 +509,14 @@ describe Braintree::Subscription do
         add_ons = subscription.add_ons.sort_by { |add_on| add_on.id }
 
         add_ons.first.id.should == "increase_10"
-        add_ons.first.amount.should == BigDecimal.new("50.00")
+        add_ons.first.amount.should == BigDecimal("50.00")
         add_ons.first.quantity.should == 2
         add_ons.first.number_of_billing_cycles.should == 5
         add_ons.first.never_expires?.should be(false)
         add_ons.first.current_billing_cycle.should == 0
 
         add_ons.last.id.should == "increase_20"
-        add_ons.last.amount.should == BigDecimal.new("20.00")
+        add_ons.last.amount.should == BigDecimal("20.00")
         add_ons.last.quantity.should == 1
         add_ons.last.current_billing_cycle.should == 0
 
@@ -524,12 +524,12 @@ describe Braintree::Subscription do
         discounts = subscription.discounts.sort_by { |discount| discount.id }
 
         discounts.first.id.should == "discount_11"
-        discounts.first.amount.should == BigDecimal.new("11.00")
+        discounts.first.amount.should == BigDecimal("11.00")
         discounts.first.quantity.should == 1
         discounts.first.current_billing_cycle.should == 0
 
         discounts.last.id.should == "discount_7"
-        discounts.last.amount.should == BigDecimal.new("15.00")
+        discounts.last.amount.should == BigDecimal("15.00")
         discounts.last.quantity.should == 3
         discounts.last.number_of_billing_cycles.should be_nil
         discounts.last.never_expires?.should be(true)
@@ -553,13 +553,13 @@ describe Braintree::Subscription do
 
         subscription.add_ons.size.should == 1
         subscription.add_ons.first.id.should == "increase_20"
-        subscription.add_ons.first.amount.should == BigDecimal.new("20.00")
+        subscription.add_ons.first.amount.should == BigDecimal("20.00")
         subscription.add_ons.first.quantity.should == 1
         subscription.add_ons.first.current_billing_cycle.should == 0
 
         subscription.discounts.size.should == 1
         subscription.discounts.last.id.should == "discount_11"
-        subscription.discounts.last.amount.should == BigDecimal.new("11.00")
+        subscription.discounts.last.amount.should == BigDecimal("11.00")
         subscription.discounts.last.quantity.should == 1
         subscription.discounts.last.current_billing_cycle.should == 0
       end
@@ -582,30 +582,30 @@ describe Braintree::Subscription do
         add_ons = subscription.add_ons.sort_by { |add_on| add_on.id }
 
         add_ons[0].id.should == "increase_10"
-        add_ons[0].amount.should == BigDecimal.new("10.00")
+        add_ons[0].amount.should == BigDecimal("10.00")
         add_ons[0].quantity.should == 1
 
         add_ons[1].id.should == "increase_20"
-        add_ons[1].amount.should == BigDecimal.new("20.00")
+        add_ons[1].amount.should == BigDecimal("20.00")
         add_ons[1].quantity.should == 1
 
         add_ons[2].id.should == "increase_30"
-        add_ons[2].amount.should == BigDecimal.new("30.00")
+        add_ons[2].amount.should == BigDecimal("30.00")
         add_ons[2].quantity.should == 1
 
         subscription.discounts.size.should == 3
         discounts = subscription.discounts.sort_by { |discount| discount.id }
 
         discounts[0].id.should == "discount_11"
-        discounts[0].amount.should == BigDecimal.new("11.00")
+        discounts[0].amount.should == BigDecimal("11.00")
         discounts[0].quantity.should == 1
 
         discounts[1].id.should == "discount_15"
-        discounts[1].amount.should == BigDecimal.new("15.00")
+        discounts[1].amount.should == BigDecimal("15.00")
         discounts[1].quantity.should == 1
 
         discounts[2].id.should == "discount_7"
-        discounts[2].amount.should == BigDecimal.new("7.00")
+        discounts[2].amount.should == BigDecimal("7.00")
         discounts[2].quantity.should == 1
       end
 
@@ -824,7 +824,7 @@ describe Braintree::Subscription do
         result.success?.should == true
         result.subscription.id.should =~ /#{new_id}/
         result.subscription.plan_id.should == SpecHelper::TrialPlan[:id]
-        result.subscription.price.should == BigDecimal.new("9999.88")
+        result.subscription.price.should == BigDecimal("9999.88")
       end
 
       context "proration" do
@@ -1022,7 +1022,7 @@ describe Braintree::Subscription do
             :update => [
               {
                 :existing_id => subscription.add_ons.first.id,
-                :amount => BigDecimal.new("99.99"),
+                :amount => BigDecimal("99.99"),
                 :quantity => 12
               }
             ]
@@ -1031,7 +1031,7 @@ describe Braintree::Subscription do
             :update => [
               {
                 :existing_id => subscription.discounts.first.id,
-                :amount => BigDecimal.new("88.88"),
+                :amount => BigDecimal("88.88"),
                 :quantity => 9
               }
             ]
@@ -1043,13 +1043,13 @@ describe Braintree::Subscription do
         subscription.add_ons.size.should == 2
         add_ons = subscription.add_ons.sort_by { |add_on| add_on.id }
 
-        add_ons.first.amount.should == BigDecimal.new("99.99")
+        add_ons.first.amount.should == BigDecimal("99.99")
         add_ons.first.quantity.should == 12
 
         subscription.discounts.size.should == 2
         discounts = subscription.discounts.sort_by { |discount| discount.id }
 
-        discounts.last.amount.should == BigDecimal.new("88.88")
+        discounts.last.amount.should == BigDecimal("88.88")
         discounts.last.quantity.should == 9
       end
 
@@ -1075,30 +1075,30 @@ describe Braintree::Subscription do
         add_ons = subscription.add_ons.sort_by { |add_on| add_on.id }
 
         add_ons[0].id.should == "increase_10"
-        add_ons[0].amount.should == BigDecimal.new("10.00")
+        add_ons[0].amount.should == BigDecimal("10.00")
         add_ons[0].quantity.should == 1
 
         add_ons[1].id.should == "increase_20"
-        add_ons[1].amount.should == BigDecimal.new("20.00")
+        add_ons[1].amount.should == BigDecimal("20.00")
         add_ons[1].quantity.should == 1
 
         add_ons[2].id.should == "increase_30"
-        add_ons[2].amount.should == BigDecimal.new("30.00")
+        add_ons[2].amount.should == BigDecimal("30.00")
         add_ons[2].quantity.should == 1
 
         subscription.discounts.size.should == 3
         discounts = subscription.discounts.sort_by { |discount| discount.id }
 
         discounts[0].id.should == "discount_11"
-        discounts[0].amount.should == BigDecimal.new("11.00")
+        discounts[0].amount.should == BigDecimal("11.00")
         discounts[0].quantity.should == 1
 
         discounts[1].id.should == "discount_15"
-        discounts[1].amount.should == BigDecimal.new("15.00")
+        discounts[1].amount.should == BigDecimal("15.00")
         discounts[1].quantity.should == 1
 
         discounts[2].id.should == "discount_7"
-        discounts[2].amount.should == BigDecimal.new("7.00")
+        discounts[2].amount.should == BigDecimal("7.00")
         discounts[2].quantity.should == 1
       end
 
@@ -1123,12 +1123,12 @@ describe Braintree::Subscription do
 
         subscription.add_ons.size.should == 1
 
-        subscription.add_ons[0].amount.should == BigDecimal.new("30.00")
+        subscription.add_ons[0].amount.should == BigDecimal("30.00")
         subscription.add_ons[0].quantity.should == 1
 
         subscription.discounts.size.should == 1
 
-        subscription.discounts[0].amount.should == BigDecimal.new("15.00")
+        subscription.discounts[0].amount.should == BigDecimal("15.00")
         subscription.discounts[0].quantity.should == 1
       end
 
@@ -1151,11 +1151,11 @@ describe Braintree::Subscription do
         subscription = result.subscription
 
         subscription.add_ons.size.should == 1
-        subscription.add_ons.first.amount.should == BigDecimal.new("20.00")
+        subscription.add_ons.first.amount.should == BigDecimal("20.00")
         subscription.add_ons.first.quantity.should == 1
 
         subscription.discounts.size.should == 1
-        subscription.discounts.last.amount.should == BigDecimal.new("11.00")
+        subscription.discounts.last.amount.should == BigDecimal("11.00")
         subscription.discounts.last.quantity.should == 1
       end
     end
@@ -1180,7 +1180,7 @@ describe Braintree::Subscription do
 
       subscription.id.should =~ /#{new_id}/
       subscription.plan_id.should == SpecHelper::TrialPlan[:id]
-      subscription.price.should == BigDecimal.new("9999.88")
+      subscription.price.should == BigDecimal("9999.88")
     end
 
     it "raises a ValidationsFailed if invalid" do
@@ -1439,7 +1439,7 @@ describe Braintree::Subscription do
         collection.should_not include(active_subscription)
         collection.each do |s|
           s.status.should == Braintree::Subscription::Status::PastDue
-          s.balance.should == BigDecimal.new("6.00")
+          s.balance.should == BigDecimal("6.00")
         end
       end
 
@@ -1711,7 +1711,7 @@ describe Braintree::Subscription do
       result.success?.should == true
       transaction = result.transaction
 
-      transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       transaction.processor_authorization_code.should_not be_nil
       transaction.type.should == Braintree::Transaction::Type::Sale
       transaction.status.should == Braintree::Transaction::Status::Authorized
@@ -1729,7 +1729,7 @@ describe Braintree::Subscription do
       result.success?.should == true
       transaction = result.transaction
 
-      transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       transaction.processor_authorization_code.should_not be_nil
       transaction.type.should == Braintree::Transaction::Type::Sale
       transaction.status.should == Braintree::Transaction::Status::SubmittedForSettlement
@@ -1747,7 +1747,7 @@ describe Braintree::Subscription do
       result.success?.should == true
       transaction = result.transaction
 
-      transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       transaction.processor_authorization_code.should_not be_nil
       transaction.type.should == Braintree::Transaction::Type::Sale
       transaction.status.should == Braintree::Transaction::Status::SubmittedForSettlement

--- a/spec/integration/braintree/transaction_line_item_spec.rb
+++ b/spec/integration/braintree/transaction_line_item_spec.rb
@@ -27,11 +27,11 @@ describe Braintree::TransactionLineItem do
       line_items = Braintree::TransactionLineItem.find_all(transaction.id)
 
       line_item = line_items[0]
-      line_item.quantity.should == BigDecimal.new("1.0232")
+      line_item.quantity.should == BigDecimal("1.0232")
       line_item.name.should == "Name #1"
       line_item.kind.should == "debit"
-      line_item.unit_amount.should == BigDecimal.new("45.1232")
-      line_item.total_amount.should == BigDecimal.new("45.15")
+      line_item.unit_amount.should == BigDecimal("45.1232")
+      line_item.total_amount.should == BigDecimal("45.15")
     end
   end
 end

--- a/spec/integration/braintree/transaction_search_spec.rb
+++ b/spec/integration/braintree/transaction_search_spec.rb
@@ -538,7 +538,7 @@ describe Braintree::Transaction, "search" do
 
         it "can also take BigDecimal for amount" do
           transaction = Braintree::Transaction.sale!(
-            :amount => BigDecimal.new("1000.00"),
+            :amount => BigDecimal("1000.00"),
             :credit_card => {
             :number => Braintree::Test::CreditCardNumbers::Visa,
             :expiration_date => "05/12"
@@ -547,7 +547,7 @@ describe Braintree::Transaction, "search" do
 
           collection = Braintree::Transaction.search do |search|
             search.id.is transaction.id
-            search.amount <= BigDecimal.new("1000.00")
+            search.amount <= BigDecimal("1000.00")
           end
 
           collection.maximum_size.should == 1

--- a/spec/integration/braintree/transaction_spec.rb
+++ b/spec/integration/braintree/transaction_spec.rb
@@ -41,7 +41,7 @@ describe Braintree::Transaction do
       transaction = clone_result.transaction
 
       transaction.id.should_not == result.transaction.id
-      transaction.amount.should == BigDecimal.new("112.44")
+      transaction.amount.should == BigDecimal("112.44")
       transaction.channel.should == "MyShoppingCartProvider"
 
       transaction.billing_details.country_name.should == "Botswana"
@@ -363,7 +363,7 @@ describe Braintree::Transaction do
         result.success?.should == true
         result.transaction.id.should =~ /^\w{6,}$/
         result.transaction.type.should == "sale"
-        result.transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+        result.transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
         result.transaction.processor_authorization_code.should_not be_nil
         result.transaction.voice_referral_number.should be_nil
         result.transaction.credit_card_details.bin.should == Braintree::Test::CreditCardNumbers::Elo[0, 6]
@@ -385,7 +385,7 @@ describe Braintree::Transaction do
       result.success?.should == true
       result.transaction.id.should =~ /^\w{6,}$/
       result.transaction.type.should == "sale"
-      result.transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      result.transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       result.transaction.processor_authorization_code.should_not be_nil
       result.transaction.processor_response_code.should == "1000"
       result.transaction.processor_response_text.should == "Approved"
@@ -425,7 +425,7 @@ describe Braintree::Transaction do
       result.success?.should == true
       result.transaction.id.should =~ /^\w{6,}$/
       result.transaction.type.should == "sale"
-      result.transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      result.transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       result.transaction.processor_authorization_code.should_not be_nil
       result.transaction.voice_referral_number.should be_nil
       result.transaction.credit_card_details.bin.should == Braintree::Test::CreditCardNumbers::Visa[0, 6]
@@ -1005,13 +1005,13 @@ describe Braintree::Transaction do
         :add_ons => {
           :add => [
             {
-              :amount => BigDecimal.new("11.00"),
+              :amount => BigDecimal("11.00"),
               :inherited_from_id => SpecHelper::AddOnIncrease10,
               :quantity => 2,
               :number_of_billing_cycles => 5
             },
             {
-              :amount => BigDecimal.new("21.00"),
+              :amount => BigDecimal("21.00"),
               :inherited_from_id => SpecHelper::AddOnIncrease20,
               :quantity => 3,
               :number_of_billing_cycles => 6
@@ -1021,7 +1021,7 @@ describe Braintree::Transaction do
         :discounts => {
           :add => [
             {
-              :amount => BigDecimal.new("7.50"),
+              :amount => BigDecimal("7.50"),
               :inherited_from_id => SpecHelper::Discount7,
               :quantity => 2,
               :never_expires => true
@@ -1039,13 +1039,13 @@ describe Braintree::Transaction do
       add_ons = transaction.add_ons.sort_by { |add_on| add_on.id }
 
       add_ons.first.id.should == "increase_10"
-      add_ons.first.amount.should == BigDecimal.new("11.00")
+      add_ons.first.amount.should == BigDecimal("11.00")
       add_ons.first.quantity.should == 2
       add_ons.first.number_of_billing_cycles.should == 5
       add_ons.first.never_expires?.should be(false)
 
       add_ons.last.id.should == "increase_20"
-      add_ons.last.amount.should == BigDecimal.new("21.00")
+      add_ons.last.amount.should == BigDecimal("21.00")
       add_ons.last.quantity.should == 3
       add_ons.last.number_of_billing_cycles.should == 6
       add_ons.last.never_expires?.should be(false)
@@ -1053,7 +1053,7 @@ describe Braintree::Transaction do
       transaction.discounts.size.should == 1
 
       transaction.discounts.first.id.should == "discount_7"
-      transaction.discounts.first.amount.should == BigDecimal.new("7.50")
+      transaction.discounts.first.amount.should == BigDecimal("7.50")
       transaction.discounts.first.quantity.should == 2
       transaction.discounts.first.number_of_billing_cycles.should be_nil
       transaction.discounts.first.never_expires?.should be(true)
@@ -1112,7 +1112,7 @@ describe Braintree::Transaction do
           :purchase_order_number => '12345678901234567'
         )
         result.success?.should == true
-        result.transaction.tax_amount.should == BigDecimal.new("0.05")
+        result.transaction.tax_amount.should == BigDecimal("0.05")
         result.transaction.tax_exempt.should == false
         result.transaction.purchase_order_number.should == '12345678901234567'
       end
@@ -1124,11 +1124,11 @@ describe Braintree::Transaction do
             :number => Braintree::Test::CreditCardNumbers::Visa,
             :expiration_date => "05/2009"
           },
-          :tax_amount => BigDecimal.new('1.99'),
+          :tax_amount => BigDecimal('1.99'),
           :tax_exempt => true
         )
         result.success?.should == true
-        result.transaction.tax_amount.should == BigDecimal.new("1.99")
+        result.transaction.tax_amount.should == BigDecimal("1.99")
         result.transaction.tax_exempt.should == true
         result.transaction.purchase_order_number.should be_nil
       end
@@ -1355,7 +1355,7 @@ describe Braintree::Transaction do
           :service_fee_amount => "1.00"
         )
         result.success?.should == true
-        result.transaction.service_fee_amount.should == BigDecimal.new("1.00")
+        result.transaction.service_fee_amount.should == BigDecimal("1.00")
       end
 
       it "raises an error if transaction merchant account is a master" do
@@ -2465,7 +2465,7 @@ describe Braintree::Transaction do
         result.transaction.id.should =~ /^\w{6,}$/
         result.transaction.type.should == "sale"
         result.transaction.payment_instrument_type.should == Braintree::PaymentInstrumentType::IdealPayment
-        result.transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+        result.transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
         result.transaction.status.should == Braintree::Transaction::Status::Settled
         result.transaction.ideal_payment_details.ideal_payment_id.should =~ /^idealpayment_\w{6,}$/
         result.transaction.ideal_payment_details.ideal_transaction_id.should =~ /^\d{16,}$/
@@ -2525,11 +2525,11 @@ describe Braintree::Transaction do
         result.success?.should == true
         result.transaction.line_items.length.should == 1
         line_item = result.transaction.line_items[0]
-        line_item.quantity.should == BigDecimal.new("1.0232")
+        line_item.quantity.should == BigDecimal("1.0232")
         line_item.name.should == "Name #1"
         line_item.kind.should == "debit"
-        line_item.unit_amount.should == BigDecimal.new("45.1232")
-        line_item.total_amount.should == BigDecimal.new("45.15")
+        line_item.unit_amount.should == BigDecimal("45.1232")
+        line_item.total_amount.should == BigDecimal("45.15")
       end
 
       it "allows creation with single line item with zero amount fields and returns it" do
@@ -2553,14 +2553,14 @@ describe Braintree::Transaction do
         result.success?.should == true
         result.transaction.line_items.length.should == 1
         line_item = result.transaction.line_items[0]
-        line_item.quantity.should == BigDecimal.new("1.0232")
+        line_item.quantity.should == BigDecimal("1.0232")
         line_item.name.should == "Name #1"
         line_item.kind.should == "debit"
-        line_item.unit_amount.should == BigDecimal.new("45.1232")
-        line_item.total_amount.should == BigDecimal.new("45.15")
-        line_item.unit_tax_amount.should == BigDecimal.new("0")
-        line_item.discount_amount.should == BigDecimal.new("0")
-        line_item.tax_amount.should == BigDecimal.new("0")
+        line_item.unit_amount.should == BigDecimal("45.1232")
+        line_item.total_amount.should == BigDecimal("45.15")
+        line_item.unit_tax_amount.should == BigDecimal("0")
+        line_item.discount_amount.should == BigDecimal("0")
+        line_item.tax_amount.should == BigDecimal("0")
       end
 
       it "allows creation with single line item and returns it" do
@@ -2589,16 +2589,16 @@ describe Braintree::Transaction do
         result.success?.should == true
         result.transaction.line_items.length.should == 1
         line_item = result.transaction.line_items[0]
-        line_item.quantity.should == BigDecimal.new("1.0232")
+        line_item.quantity.should == BigDecimal("1.0232")
         line_item.name.should == "Name #1"
         line_item.description.should == "Description #1"
         line_item.kind.should == "debit"
-        line_item.unit_amount.should == BigDecimal.new("45.1232")
-        line_item.unit_tax_amount.should == BigDecimal.new("1.23")
+        line_item.unit_amount.should == BigDecimal("45.1232")
+        line_item.unit_tax_amount.should == BigDecimal("1.23")
         line_item.unit_of_measure.should == "gallon"
-        line_item.discount_amount.should == BigDecimal.new("1.02")
-        line_item.tax_amount.should == BigDecimal.new("4.50")
-        line_item.total_amount.should == BigDecimal.new("45.15")
+        line_item.discount_amount.should == BigDecimal("1.02")
+        line_item.tax_amount.should == BigDecimal("4.50")
+        line_item.total_amount.should == BigDecimal("45.15")
         line_item.product_code.should == "23434"
         line_item.commodity_code.should == "9SAASSD8724"
         line_item.url.should == "https://example.com/products/23434"
@@ -2636,24 +2636,24 @@ describe Braintree::Transaction do
         result.success?.should == true
         result.transaction.line_items.length.should == 2
         line_item_1 = result.transaction.line_items.find { |line_item| line_item.name == "Name #1" }
-        line_item_1.quantity.should == BigDecimal.new("1.0232")
+        line_item_1.quantity.should == BigDecimal("1.0232")
         line_item_1.name.should == "Name #1"
         line_item_1.kind.should == "debit"
-        line_item_1.unit_amount.should == BigDecimal.new("45.1232")
+        line_item_1.unit_amount.should == BigDecimal("45.1232")
         line_item_1.unit_of_measure.should == "gallon"
-        line_item_1.discount_amount.should == BigDecimal.new("1.02")
-        line_item_1.tax_amount.should == BigDecimal.new("4.50")
-        line_item_1.total_amount.should == BigDecimal.new("45.15")
+        line_item_1.discount_amount.should == BigDecimal("1.02")
+        line_item_1.tax_amount.should == BigDecimal("4.50")
+        line_item_1.total_amount.should == BigDecimal("45.15")
         line_item_1.product_code.should == "23434"
         line_item_1.commodity_code.should == "9SAASSD8724"
         line_item_2 = result.transaction.line_items.find { |line_item| line_item.name == "Name #2" }
-        line_item_2.quantity.should == BigDecimal.new("2.02")
+        line_item_2.quantity.should == BigDecimal("2.02")
         line_item_2.name.should == "Name #2"
         line_item_2.kind.should == "credit"
-        line_item_2.unit_amount.should == BigDecimal.new("5")
+        line_item_2.unit_amount.should == BigDecimal("5")
         line_item_2.unit_of_measure.should == "gallon"
-        line_item_2.total_amount.should == BigDecimal.new("10.1")
-        line_item_2.tax_amount.should == BigDecimal.new("1.50")
+        line_item_2.total_amount.should == BigDecimal("10.1")
+        line_item_2.tax_amount.should == BigDecimal("1.50")
         line_item_2.discount_amount.should == nil
         line_item_2.product_code.should == nil
         line_item_2.commodity_code.should == nil
@@ -3649,7 +3649,7 @@ describe Braintree::Transaction do
         result.errors.for(:transaction).on(:line_items)[0].code.should == Braintree::ErrorCodes::Transaction::TooManyLineItems
       end
     end
-    
+
     context "level 3 summary data" do
       it "accepts level 3 summary data" do
         result = Braintree::Transaction.create(
@@ -3969,7 +3969,7 @@ describe Braintree::Transaction do
       )
       transaction.id.should =~ /^\w{6,}$/
       transaction.type.should == "sale"
-      transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       transaction.credit_card_details.bin.should == Braintree::Test::CreditCardNumbers::Visa[0, 6]
       transaction.credit_card_details.last_4.should == Braintree::Test::CreditCardNumbers::Visa[-4..-1]
       transaction.credit_card_details.expiration_date.should == "05/2009"
@@ -4089,7 +4089,7 @@ describe Braintree::Transaction do
       result.success?.should == true
       result.transaction.id.should =~ /^\w{6,}$/
       result.transaction.type.should == "sale"
-      result.transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      result.transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       result.transaction.credit_card_details.bin.should == Braintree::Test::CreditCardNumbers::Visa[0, 6]
       result.transaction.credit_card_details.last_4.should == Braintree::Test::CreditCardNumbers::Visa[-4..-1]
       result.transaction.credit_card_details.expiration_date.should == "05/2009"
@@ -4143,7 +4143,7 @@ describe Braintree::Transaction do
       transaction.id.should =~ /\A\w{6,}\z/
       transaction.type.should == "sale"
       transaction.status.should == Braintree::Transaction::Status::Authorized
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.currency_iso_code.should == "USD"
       transaction.order_id.should == "123"
       transaction.channel.should == "MyShoppingCartProvider"
@@ -4671,7 +4671,7 @@ describe Braintree::Transaction do
       )
       transaction.id.should =~ /^\w{6,}$/
       transaction.type.should == "sale"
-      transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       transaction.credit_card_details.bin.should == Braintree::Test::CreditCardNumbers::Visa[0, 6]
       transaction.credit_card_details.last_4.should == Braintree::Test::CreditCardNumbers::Visa[-4..-1]
       transaction.credit_card_details.expiration_date.should == "05/2009"
@@ -4711,10 +4711,10 @@ describe Braintree::Transaction do
           :expiration_date => "06/2009"
         }
       )
-      transaction.amount.should == BigDecimal.new("1000.00")
+      transaction.amount.should == BigDecimal("1000.00")
       result = Braintree::Transaction.submit_for_settlement(transaction.id, "999.99")
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("999.99")
+      result.transaction.amount.should == BigDecimal("999.99")
       result.transaction.status.should == Braintree::Transaction::Status::SubmittedForSettlement
       result.transaction.updated_at.between?(Time.now - 60, Time.now).should == true
     end
@@ -4783,7 +4783,7 @@ describe Braintree::Transaction do
           :expiration_date => "06/2009"
         }
       )
-      transaction.amount.should == BigDecimal.new("1000.00")
+      transaction.amount.should == BigDecimal("1000.00")
       result = Braintree::Transaction.submit_for_settlement(transaction.id, "1000.01")
       result.success?.should == false
       result.errors.for(:transaction).on(:amount)[0].code.should == Braintree::ErrorCodes::Transaction::SettlementAmountIsTooLarge
@@ -4846,7 +4846,7 @@ describe Braintree::Transaction do
           :expiration_date => "06/2009"
         }
       )
-      transaction.amount.should == BigDecimal.new("1000.00")
+      transaction.amount.should == BigDecimal("1000.00")
       expect do
         Braintree::Transaction.submit_for_settlement!(transaction.id, "1000.01")
       end.to raise_error(Braintree::ValidationsFailed)
@@ -4886,7 +4886,7 @@ describe Braintree::Transaction do
           :order_id => '456'
         })
         result.success?.should == true
-        result.transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize) - 1
+        result.transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize) - 1
         result.transaction.order_id.should == '456'
         result.transaction.descriptor.name.should ==  '456*123456789012345678'
       end
@@ -5216,7 +5216,7 @@ describe Braintree::Transaction do
           :expiration_date => "06/2009"
         }
       )
-      transaction.amount.should == BigDecimal.new("1000.00")
+      transaction.amount.should == BigDecimal("1000.00")
       expect do
         Braintree::Transaction.submit_for_partial_settlement!(transaction.id, "1000.01")
       end.to raise_error(Braintree::ValidationsFailed)
@@ -5330,7 +5330,7 @@ describe Braintree::Transaction do
       result.success?.should == true
       result.transaction.id.should =~ /^\w{6,}$/
       result.transaction.type.should == "credit"
-      result.transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      result.transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       result.transaction.credit_card_details.bin.should == Braintree::Test::CreditCardNumbers::Visa[0, 6]
       result.transaction.credit_card_details.last_4.should == Braintree::Test::CreditCardNumbers::Visa[-4..-1]
       result.transaction.credit_card_details.expiration_date.should == "05/2009"
@@ -5405,7 +5405,7 @@ describe Braintree::Transaction do
       )
       transaction.id.should =~ /^\w{6,}$/
       transaction.type.should == "credit"
-      transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+      transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
       transaction.credit_card_details.bin.should == Braintree::Test::CreditCardNumbers::Visa[0, 6]
       transaction.credit_card_details.last_4.should == Braintree::Test::CreditCardNumbers::Visa[-4..-1]
       transaction.credit_card_details.expiration_date.should == "05/2009"
@@ -5447,7 +5447,7 @@ describe Braintree::Transaction do
       result.success?.should == true
       transaction = result.transaction
       transaction.type.should == "sale"
-      transaction.amount.should == BigDecimal.new("1000.00")
+      transaction.amount.should == BigDecimal("1000.00")
       transaction.credit_card_details.bin.should == Braintree::Test::CreditCardNumbers::Visa[0, 6]
       transaction.credit_card_details.last_4.should == Braintree::Test::CreditCardNumbers::Visa[-4..-1]
       transaction.credit_card_details.expiration_date.should == "05/2009"
@@ -5534,7 +5534,7 @@ describe Braintree::Transaction do
       transaction.id.should =~ /\A\w{6,}\z/
       transaction.type.should == "sale"
       transaction.status.should == Braintree::Transaction::Status::Authorized
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.order_id.should == "123"
       transaction.channel.should == "MyShoppingCartProvider"
       transaction.processor_response_code.should == "1000"
@@ -5965,10 +5965,10 @@ describe Braintree::Transaction do
           :expiration_date => "06/2009"
         }
       )
-      transaction.amount.should == BigDecimal.new("1000.00")
+      transaction.amount.should == BigDecimal("1000.00")
       result = transaction.submit_for_settlement("999.99")
       result.success?.should == true
-      transaction.amount.should == BigDecimal.new("999.99")
+      transaction.amount.should == BigDecimal("999.99")
     end
 
     it "updates the transaction attributes" do
@@ -5979,10 +5979,10 @@ describe Braintree::Transaction do
           :expiration_date => "06/2009"
         }
       )
-      transaction.amount.should == BigDecimal.new("1000.00")
+      transaction.amount.should == BigDecimal("1000.00")
       result = transaction.submit_for_settlement("999.99")
       result.success?.should == true
-      transaction.amount.should == BigDecimal.new("999.99")
+      transaction.amount.should == BigDecimal("999.99")
       transaction.status.should == Braintree::Transaction::Status::SubmittedForSettlement
       transaction.updated_at.between?(Time.now - 60, Time.now).should == true
     end
@@ -5995,7 +5995,7 @@ describe Braintree::Transaction do
           :expiration_date => "06/2009"
         }
       )
-      transaction.amount.should == BigDecimal.new("1000.00")
+      transaction.amount.should == BigDecimal("1000.00")
       result = transaction.submit_for_settlement("1000.01")
       result.success?.should == false
       result.errors.for(:transaction).on(:amount)[0].code.should == Braintree::ErrorCodes::Transaction::SettlementAmountIsTooLarge
@@ -6025,7 +6025,7 @@ describe Braintree::Transaction do
           :expiration_date => "06/2009"
         }
       )
-      transaction.amount.should == BigDecimal.new("1000.00")
+      transaction.amount.should == BigDecimal("1000.00")
       expect do
         transaction.submit_for_settlement!("1000.01")
       end.to raise_error(Braintree::ValidationsFailed)

--- a/spec/integration/braintree/transaction_us_bank_account_spec.rb
+++ b/spec/integration/braintree/transaction_us_bank_account_spec.rb
@@ -28,7 +28,7 @@ describe Braintree::Transaction do
             result.transaction.id.should =~ /^\w{6,}$/
             result.transaction.type.should == "sale"
             result.transaction.payment_instrument_type.should == Braintree::PaymentInstrumentType::UsBankAccount
-            result.transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+            result.transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
             result.transaction.status.should == Braintree::Transaction::Status::SettlementPending
             result.transaction.us_bank_account_details.routing_number.should == "011000015"
             result.transaction.us_bank_account_details.last_4.should == "0000"
@@ -73,7 +73,7 @@ describe Braintree::Transaction do
 
             transaction.id.should =~ /^\w{6,}$/
             transaction.type.should == "sale"
-            transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+            transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
             transaction.status.should == Braintree::Transaction::Status::SettlementPending
             transaction.us_bank_account_details.routing_number.should == "011000015"
             transaction.us_bank_account_details.last_4.should == "0000"
@@ -114,7 +114,7 @@ describe Braintree::Transaction do
 
             transaction.id.should =~ /^\w{6,}$/
             transaction.type.should == "sale"
-            transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+            transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
             transaction.status.should == Braintree::Transaction::Status::SettlementPending
             transaction.us_bank_account_details.routing_number.should == "011000015"
             transaction.us_bank_account_details.last_4.should == "0000"
@@ -247,7 +247,7 @@ describe Braintree::Transaction do
             result.transaction.id.should =~ /^\w{6,}$/
             result.transaction.type.should == "sale"
             result.transaction.payment_instrument_type.should == Braintree::PaymentInstrumentType::UsBankAccount
-            result.transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+            result.transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
             result.transaction.status.should == Braintree::Transaction::Status::SettlementPending
             result.transaction.us_bank_account_details.routing_number.should == "011000015"
             result.transaction.us_bank_account_details.last_4.should == "0000"
@@ -294,7 +294,7 @@ describe Braintree::Transaction do
 
             transaction.id.should =~ /^\w{6,}$/
             transaction.type.should == "sale"
-            transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+            transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
             transaction.status.should == Braintree::Transaction::Status::SettlementPending
             transaction.us_bank_account_details.routing_number.should == "011000015"
             transaction.us_bank_account_details.last_4.should == "0000"
@@ -335,7 +335,7 @@ describe Braintree::Transaction do
 
             transaction.id.should =~ /^\w{6,}$/
             transaction.type.should == "sale"
-            transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+            transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
             transaction.status.should == Braintree::Transaction::Status::SettlementPending
             transaction.us_bank_account_details.routing_number.should == "011000015"
             transaction.us_bank_account_details.last_4.should == "0000"
@@ -369,7 +369,7 @@ describe Braintree::Transaction do
 
             transaction.id.should =~ /^\w{6,}$/
             transaction.type.should == "sale"
-            transaction.amount.should == BigDecimal.new(Braintree::Test::TransactionAmounts::Authorize)
+            transaction.amount.should == BigDecimal(Braintree::Test::TransactionAmounts::Authorize)
             transaction.status.should == Braintree::Transaction::Status::SettlementPending
             transaction.us_bank_account_details.routing_number.should == "021000021"
             transaction.us_bank_account_details.last_4.should == "0000"

--- a/spec/integration/braintree/transparent_redirect_spec.rb
+++ b/spec/integration/braintree/transparent_redirect_spec.rb
@@ -51,7 +51,7 @@ describe Braintree::TransparentRedirect do
         result.success?.should == true
         transaction = result.transaction
         transaction.type.should == "sale"
-        transaction.amount.should == BigDecimal.new("1000.00")
+        transaction.amount.should == BigDecimal("1000.00")
         transaction.credit_card_details.bin.should == Braintree::Test::CreditCardNumbers::Visa[0, 6]
         transaction.credit_card_details.last_4.should == Braintree::Test::CreditCardNumbers::Visa[-4..-1]
         transaction.credit_card_details.expiration_date.should == "05/2009"
@@ -78,7 +78,7 @@ describe Braintree::TransparentRedirect do
         query_string_response = SpecHelper.simulate_form_post_for_tr(tr_data, params)
         result = Braintree::TransparentRedirect.confirm(query_string_response)
         result.success?.should == true
-        result.transaction.service_fee_amount.should == BigDecimal.new("1.00")
+        result.transaction.service_fee_amount.should == BigDecimal("1.00")
       end
 
       it "returns an error when there's an error" do

--- a/spec/integration/braintree/us_bank_account_spec.rb
+++ b/spec/integration/braintree/us_bank_account_spec.rb
@@ -55,7 +55,7 @@ describe Braintree::UsBankAccount do
       )
 
       result.success?.should == true
-      result.transaction.amount.should == BigDecimal.new("100.00")
+      result.transaction.amount.should == BigDecimal("100.00")
       result.transaction.type.should == "sale"
       us_bank_account = result.transaction.us_bank_account_details
       us_bank_account.routing_number.should == "021000021"
@@ -88,7 +88,7 @@ describe Braintree::UsBankAccount do
         :amount => "100.00"
       )
 
-      transaction.amount.should == BigDecimal.new("100.00")
+      transaction.amount.should == BigDecimal("100.00")
       transaction.type.should == "sale"
       us_bank_account = transaction.us_bank_account_details
       us_bank_account.routing_number.should == "021000021"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ unless defined?(SPEC_HELPER_LOADED)
     TrialPlan = {
       :description => "Plan for integration tests -- with trial",
       :id => "integration_trial_plan",
-      :price => BigDecimal.new("43.21"),
+      :price => BigDecimal("43.21"),
       :trial_period => true,
       :trial_duration => 2,
       :trial_duration_unit => Braintree::Subscription::TrialDurationUnit::Day
@@ -56,14 +56,14 @@ unless defined?(SPEC_HELPER_LOADED)
     TriallessPlan = {
       :description => "Plan for integration tests -- without a trial",
       :id => "integration_trialless_plan",
-      :price => BigDecimal.new("12.34"),
+      :price => BigDecimal("12.34"),
       :trial_period => false
     }
 
     AddOnDiscountPlan = {
       :description => "Plan for integration tests -- with add-ons and discounts",
       :id => "integration_plan_with_add_ons_and_discounts",
-      :price => BigDecimal.new("9.99"),
+      :price => BigDecimal("9.99"),
       :trial_period => true,
       :trial_duration => 2,
       :trial_duration_unit => Braintree::Subscription::TrialDurationUnit::Day
@@ -72,7 +72,7 @@ unless defined?(SPEC_HELPER_LOADED)
     BillingDayOfMonthPlan = {
       :description => "Plan for integration tests -- with billing day of month",
       :id => "integration_plan_with_billing_day_of_month",
-      :price => BigDecimal.new("8.88"),
+      :price => BigDecimal("8.88"),
       :billing_day_of_month => 5
     }
 

--- a/spec/unit/braintree/credit_card_verification_spec.rb
+++ b/spec/unit/braintree/credit_card_verification_spec.rb
@@ -36,8 +36,8 @@ describe Braintree::CreditCardVerification do
   end
 
   it "accepts amount as either a String or BigDecimal" do
-    Braintree::CreditCardVerification._new(:amount => "12.34").amount.should == BigDecimal.new("12.34")
-    Braintree::CreditCardVerification._new(:amount => BigDecimal.new("12.34")).amount.should == BigDecimal.new("12.34")
+    Braintree::CreditCardVerification._new(:amount => "12.34").amount.should == BigDecimal("12.34")
+    Braintree::CreditCardVerification._new(:amount => BigDecimal("12.34")).amount.should == BigDecimal("12.34")
   end
 
   describe "self.create" do

--- a/spec/unit/braintree/modification_spec.rb
+++ b/spec/unit/braintree/modification_spec.rb
@@ -2,6 +2,6 @@ require File.expand_path(File.dirname(__FILE__) + "/../spec_helper")
 
 describe Braintree::Modification do
   it "converts string amount" do
-    Braintree::Modification._new(:amount => "100.00").amount.should == BigDecimal.new("100.00")
+    Braintree::Modification._new(:amount => "100.00").amount.should == BigDecimal("100.00")
   end
 end

--- a/spec/unit/braintree/subscription_spec.rb
+++ b/spec/unit/braintree/subscription_spec.rb
@@ -11,8 +11,8 @@ describe Braintree::Subscription do
 
   context "price" do
     it "accepts price as either a String or a BigDecimal" do
-      Braintree::Subscription._new(:gateway, default_params.merge(:price => "12.34")).price.should == BigDecimal.new("12.34")
-      Braintree::Subscription._new(:gateway, default_params.merge(:price => BigDecimal.new("12.34"))).price.should == BigDecimal.new("12.34")
+      Braintree::Subscription._new(:gateway, default_params.merge(:price => "12.34")).price.should == BigDecimal("12.34")
+      Braintree::Subscription._new(:gateway, default_params.merge(:price => BigDecimal("12.34"))).price.should == BigDecimal("12.34")
     end
 
     it "blows up if price is not a string or BigDecimal" do

--- a/spec/unit/braintree/transaction_spec.rb
+++ b/spec/unit/braintree/transaction_spec.rb
@@ -238,8 +238,8 @@ describe Braintree::Transaction do
     end
 
     it "accepts amount as either a String or a BigDecimal" do
-      Braintree::Transaction._new(:gateway, :amount => "12.34").amount.should == BigDecimal.new("12.34")
-      Braintree::Transaction._new(:gateway, :amount => BigDecimal.new("12.34")).amount.should == BigDecimal.new("12.34")
+      Braintree::Transaction._new(:gateway, :amount => "12.34").amount.should == BigDecimal("12.34")
+      Braintree::Transaction._new(:gateway, :amount => BigDecimal("12.34")).amount.should == BigDecimal("12.34")
     end
 
     it "blows up if amount is not a string or BigDecimal" do

--- a/spec/unit/braintree/util_spec.rb
+++ b/spec/unit/braintree/util_spec.rb
@@ -354,11 +354,11 @@ describe Braintree::Util do
 
   describe "self.to_big_decimal" do
     it "returns the BigDecimal when given a BigDecimal" do
-      Braintree::Util.to_big_decimal(BigDecimal.new("12.34")).should == BigDecimal.new("12.34")
+      Braintree::Util.to_big_decimal(BigDecimal("12.34")).should == BigDecimal("12.34")
     end
 
     it "returns a BigDecimal when given a string" do
-      Braintree::Util.to_big_decimal("12.34").should == BigDecimal.new("12.34")
+      Braintree::Util.to_big_decimal("12.34").should == BigDecimal("12.34")
     end
 
     it "returns nil when given nil" do

--- a/spec/unit/braintree/xml_spec.rb
+++ b/spec/unit/braintree/xml_spec.rb
@@ -108,17 +108,17 @@ describe Braintree::Xml do
 
 		context "BigDecimal" do
 			it "works for BigDecimals" do
-				hash = {:root => {:foo => BigDecimal.new("123.45")}}
+				hash = {:root => {:foo => BigDecimal("123.45")}}
 				Braintree::Xml.hash_to_xml(hash).should include("<foo>123.45</foo>")
 			end
 
 			it "works for BigDecimals with fewer than 2 digits" do
-				hash = {:root => {:foo => BigDecimal.new("1000.0")}}
+				hash = {:root => {:foo => BigDecimal("1000.0")}}
 				Braintree::Xml.hash_to_xml(hash).should include("<foo>1000.00</foo>")
 			end
 
 			it "works for BigDecimals with more than 2 digits" do
-				hash = {:root => {:foo => BigDecimal.new("12.345")}}
+				hash = {:root => {:foo => BigDecimal("12.345")}}
 				Braintree::Xml.hash_to_xml(hash).should include("<foo>12.345</foo>")
 			end
 		end


### PR DESCRIPTION
# Summary
BigDecimal#new is deprecated starting from ruby 2.5.0: https://docs.ruby-lang.org/en/2.5.0/NEWS.html#label-Stdlib+updates+-28outstanding+ones+only-29

# Checklist

- [ ] Added changelog entry
- [ ] Ran unit tests (`rake test:unit`)
