### PR TITLE
Gemspec: drop EOL'd rubyforge_project, has_rdoc

### DIFF
--- a/braintree.gemspec
+++ b/braintree.gemspec
@@ -10,6 +10,9 @@ Gem::Specification.new do |s|
   s.author = "Braintree"
   s.email = "code@getbraintree.com"
   s.homepage = "https://www.braintreepayments.com/"
+  # NEXT_MAJOR_VERSION remove this attribute as it is deprecated
+  #                    https://blog.rubygems.org/2009/05/04/1.3.3-released.html
+  s.has_rdoc = false  
   s.files = Dir.glob ["README.rdoc", "LICENSE", "lib/**/*.{rb,crt}", "spec/**/*", "*.gemspec"]
   s.add_dependency "builder", ">= 2.0.0"
   s.metadata = {

--- a/braintree.gemspec
+++ b/braintree.gemspec
@@ -10,8 +10,6 @@ Gem::Specification.new do |s|
   s.author = "Braintree"
   s.email = "code@getbraintree.com"
   s.homepage = "https://www.braintreepayments.com/"
-  s.rubyforge_project = "braintree"
-  s.has_rdoc = false
   s.files = Dir.glob ["README.rdoc", "LICENSE", "lib/**/*.{rb,crt}", "spec/**/*", "*.gemspec"]
   s.add_dependency "builder", ">= 2.0.0"
   s.metadata = {

--- a/braintree.gemspec
+++ b/braintree.gemspec
@@ -9,10 +9,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.author = "Braintree"
   s.email = "code@getbraintree.com"
-  s.homepage = "https://www.braintreepayments.com/"
-  # NEXT_MAJOR_VERSION remove this attribute as it is deprecated
-  #                    https://blog.rubygems.org/2009/05/04/1.3.3-released.html
-  s.has_rdoc = false  
+  s.homepage = "https://www.braintreepayments.com/" 
   s.files = Dir.glob ["README.rdoc", "LICENSE", "lib/**/*.{rb,crt}", "spec/**/*", "*.gemspec"]
   s.add_dependency "builder", ">= 2.0.0"
   s.metadata = {

--- a/braintree.gemspec
+++ b/braintree.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.author = "Braintree"
   s.email = "code@getbraintree.com"
-  s.homepage = "https://www.braintreepayments.com/" 
+  s.homepage = "https://www.braintreepayments.com/"
   s.files = Dir.glob ["README.rdoc", "LICENSE", "lib/**/*.{rb,crt}", "spec/**/*", "*.gemspec"]
   s.add_dependency "builder", ">= 2.0.0"
   s.metadata = {


### PR DESCRIPTION
# Summary

The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. Same with `has_rdoc`, which now always defaults to true.

[Source code location with the deprecation](https://github.com/rubygems/rubygems/blob/a7e2f87e94791206d2e7bb12ff7ce75442811ce8/lib/rubygems/specification.rb#L735)

# Checklist

- [ ] Added changelog entry (no, this is a trivial change)
- [ ] Ran unit tests (`rake test:unit`) (hoping CI will do this)
