### PR TITLE
Fix return response body, if not gzip response from braintree gateway

### DIFF
--- a/lib/braintree/http.rb
+++ b/lib/braintree/http.rb
@@ -174,7 +174,7 @@ module Braintree
       if content_encoding == "gzip"
         Zlib::GzipReader.new(StringIO.new(response.body)).read
       elsif content_encoding.nil?
-        ""
+        response.body
       else
         raise UnexpectedError, "expected a gzipped response"
       end


### PR DESCRIPTION
ENV:

Ruby 2.6.3
Braintree 2.98.0
Braintree Sandbox

Step to reproduce:

Ruby call on sandbox gateway:

```ruby
Braintree::Customer.create!(
  id: 'testing_user',
  first_name: 'Max', 
  last_name: 'Power',
  email: 'testing@example.com'
)
```

Error:

```
 NoMethodError:
       undefined method `name' for nil:NilClass
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/xml/rexml.rb:16:in `_merge_element!'
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/xml/rexml.rb:12:in `parse'
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/xml/parser.rb:15:in `hash_from_xml'
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/xml.rb:4:in `hash_from_xml'
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/http.rb:40:in `post'
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/customer_gateway.rb:112:in `_do_create'
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/customer_gateway.rb:18:in `create'
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/customer_gateway.rb:22:in `block in create!'
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/base_module.rb:5:in `return_object_or_raise'
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/customer_gateway.rb:22:in `create!'
     # /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/customer.rb:39:in `create!'
```

HTTP request:

```
#<struct VCR::Request method=:post, uri="https://api.sandbox.braintreegateway.com/merchants/<secret>/customers", body="<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customer>\n  <id>testing_user</id>\n  <first-name>Max</first-name>\n  <last-name>Power</last-name>\n  <email>testing@example.com</email>\n</customer>\n", headers={"Accept-Encoding"=>["gzip"], "Accept"=>["application/xml"], "User-Agent"=>["Braintree Ruby Gem 2.98.0"], "X-Apiversion"=>["5"], "Content-Type"=>["application/xml"], "Authorization"=>["Basic <secret>"]}>
```

HTTP response:

```
#<struct VCR::Response status=#<struct VCR::ResponseStatus code=201, message="Created">, headers={"Date"=>["Thu, 05 Sep 2019 18:34:42 GMT"], "Content-Type"=>["application/xml; charset=utf-8"], "Transfer-Encoding"=>["chunked"], "X-Frame-Options"=>["SAMEORIGIN"], "X-Xss-Protection"=>["1; mode=block"], "X-Content-Type-Options"=>["nosniff"], "X-Authentication"=>["basic_auth"], "X-User"=>["4s3cktqbswr42pms"], "Vary"=>["Accept-Encoding"], "Etag"=>["W/\"b931136b503acb826f289949976ca24e\""], "Cache-Control"=>["max-age=0, private, must-revalidate"], "X-Runtime"=>["0.122040"], "X-Request-Id"=>["01-1567708481.573-91.225.166.82-1132061"], "Content-Security-Policy"=>["frame-ancestors 'self'"], "X-Broxyid"=>["01-1567708481.573-91.225.166.82-1132061"], "Strict-Transport-Security"=>["max-age=31536000; includeSubDomains"]}, body="<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customer>\n  <id>testing_user</id>\n  <merchant-id>secret</merchant-id>\n  <first-name>Max</first-name>\n  <last-name>Power</last-name>\n  <company nil=\"true\"/>\n  <email>testing@example.com</email>\n  <phone nil=\"true\"/>\n  <fax nil=\"true\"/>\n  <website nil=\"true\"/>\n  <created-at type=\"datetime\">2019-09-05T18:34:42Z</created-at>\n  <updated-at type=\"datetime\">2019-09-05T18:34:42Z</updated-at>\n  <custom-fields/>\n  <global-id>secret</global-id>\n  <credit-cards type=\"array\"/>\n  <addresses type=\"array\"/>\n</customer>\n", http_version=nil, adapter_metadata={}>
```

From debugger:

```
From: /Users/leo/.rvm/gems/ruby-2.6.3/gems/braintree-2.98.0/lib/braintree/http.rb @ line 39 Braintree::Http#post:

    32: def post(path, params = nil, file = nil)
    33:   body = params
    34:   if !file
    35:     body = _build_xml(params)
    36:   end
    37:   response = _http_do Net::HTTP::Post, path, body, file
    38:   binding.pry
 => 39:   if response.code.to_i == 200 || response.code.to_i == 201 || response.code.to_i == 422
    40:     Xml.hash_from_xml(_body(response))
    41:   else
    42:     Util.raise_exception_for_status_code(response.code)
    43:   end
    44: end

[1] pry(#<Braintree::Http>)> content_encoding = response.header["Content-Encoding"]
=> nil
[2] pry(#<Braintree::Http>)> response.body
=> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customer>\n  <id>testing_user</id>\n  <merchant-id>secret</merchant-id>\n  <first-name>Max</first-name>\n  <last-name>Power</last-name>\n  <company nil=\"true\"/>\n  <email>testing@example.com</email>\n  <phone nil=\"true\"/>\n  <fax nil=\"true\"/>\n  <website nil=\"true\"/>\n  <created-at type=\"datetime\">2019-09-05T18:34:42Z</created-at>\n  <updated-at type=\"datetime\">2019-09-05T18:34:42Z</updated-at>\n  <custom-fields/>\n  <global-id>secret</global-id>\n  <credit-cards type=\"array\"/>\n  <addresses type=\"array\"/>\n</customer>\n"
```