### PR TITLE
ResourceCollection#first(n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##unreleased
+* Allows `ResourceCollection#first` to receive one argument and return that argument number of items
+
 ## 3.1.0
 * Add `acquirer_reference_number` to `Transaction`
 * Add `billing_agreement_id` to `PayPalDetails`

--- a/lib/braintree/resource_collection.rb
+++ b/lib/braintree/resource_collection.rb
@@ -22,9 +22,14 @@ module Braintree
       @ids.empty?
     end
 
-    # Returns the first item in the collection or nil if the collection is empty
-    def first
-      @paging_block.call([@ids.first]).first
+    # Returns the first or the first N items in the collection or nil if the collection is empty
+    def first(amount = 1)
+      return nil if @ids.empty?
+      return @paging_block.call([@ids.first]).first if amount == 1
+
+      @ids.first(amount).each_slice(@page_size).flat_map do |page_of_ids|
+        @paging_block.call(page_of_ids)
+      end
     end
 
     # Only the maximum size of a resource collection can be determined since the data on the server can change while

--- a/spec/unit/braintree/resource_collection_spec.rb
+++ b/spec/unit/braintree/resource_collection_spec.rb
@@ -18,6 +18,35 @@ describe "Braintree::ResourceCollection" do
     end
   end
 
+  describe "#first" do
+    it 'returns nil with no results' do
+      values = %w(a b c d e)
+      collection = Braintree::ResourceCollection.new(:search_results => {:ids => [], :page_size => 2}) do |ids|
+        ids.map {|id| values[id] }
+      end
+
+      collection.first.should == nil
+    end
+
+    it 'returns the first occourence' do
+      values = %w(a b c d e)
+      collection = Braintree::ResourceCollection.new(:search_results => {:ids => [0,1,2,3,4], :page_size => 2}) do |ids|
+        ids.map {|id| values[id] }
+      end
+
+      collection.first.should == 'a'
+    end
+
+    it 'returns the first N occourences' do
+      values = %w(a b c d e)
+      collection = Braintree::ResourceCollection.new(:search_results => {:ids => [0,1,2,3,4], :page_size => 2}) do |ids|
+        ids.map {|id| values[id] }
+      end
+
+      collection.first(4).should == ['a','b','c','d']
+    end
+  end
+
   describe "#ids" do
     it "returns a list of the resource collection ids" do
       collection = Braintree::ResourceCollection.new(:search_results => {:ids => [0,1,2,3,4], :page_size => 2})

--- a/spec/unit/braintree/resource_collection_spec.rb
+++ b/spec/unit/braintree/resource_collection_spec.rb
@@ -28,22 +28,22 @@ describe "Braintree::ResourceCollection" do
       collection.first.should == nil
     end
 
-    it 'returns the first occourence' do
-      values = %w(a b c d e)
-      collection = Braintree::ResourceCollection.new(:search_results => {:ids => [0,1,2,3,4], :page_size => 2}) do |ids|
-        ids.map {|id| values[id] }
+    context 'with results' do
+      let(:collection) do
+        values = %w(a b c d e)
+
+        Braintree::ResourceCollection.new(:search_results => {:ids => [0,1,2,3,4], :page_size => 2}) do |ids|
+          ids.map {|id| values[id] }
+        end
       end
 
-      collection.first.should == 'a'
-    end
-
-    it 'returns the first N occourences' do
-      values = %w(a b c d e)
-      collection = Braintree::ResourceCollection.new(:search_results => {:ids => [0,1,2,3,4], :page_size => 2}) do |ids|
-        ids.map {|id| values[id] }
+      it 'returns the first occourence' do
+        collection.first.should == 'a'
       end
 
-      collection.first(4).should == ['a','b','c','d']
+      it 'returns the first N occourences' do
+        collection.first(4).should == ['a','b','c','d']
+      end
     end
   end
 


### PR DESCRIPTION
# Summary

The current implementation of ResourceCollection#first does not allow to get more than 1 item, forcing us to go through the entire collection (and possibly many calls for the api on searches), this modification allow us to get only the first few items as in `foobar.first(10)`

This PR implements that feature and adds specs for the expected scenarios.

# Checklist
* [x]  Added changelog entry (If there isn't an `#unreleased` section, add that and your changelog entry to the top of the changelog)
* [x]  Ran unit tests (`rake test:unit`)