### PR TITLE
Allow looking up ActiveSupport::TimeWithZone on xml generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## unreleased
+* Add support for `ActiveSupport::TimeWithZone` when generating XML
+
 ## 3.3.0
 * Add `decision_reasons` and `transaction_risk_score` fields to `RiskData`
 * Add `acs_transaction_id`, `pares_status`, `three_d_secure_transaction_id`, `lookup`, and `authentication` to `ThreeDSecureInfo`

--- a/lib/braintree/xml/generator.rb
+++ b/lib/braintree/xml/generator.rb
@@ -12,6 +12,7 @@ module Braintree
         "Date"       => "datetime",
         "DateTime"   => "datetime",
         "Time"       => "datetime",
+        "ActiveSupport::TimeWithZone" => "datetime"
       }
 
       XML_FORMATTING_NAMES = {


### PR DESCRIPTION
# Summary

rails/rails#41835 introduced a deprecation notice which will make ActiveSupport::TimeWithZone return it's actual class name in the future instead of `Time` in Rails 7.1

This mapping will ensure correct formatting when using Rails and the braintree gem.

Closes https://github.com/braintree/braintree_ruby/issues/208

# Checklist

- [x] Added changelog entry (If there isn't an `#unreleased` section, add that and your changelog entry to the top of the changelog)
- [x] Ran unit tests (`rake test:unit`)

<!-- **For Braintree Developers only, don't forget:**
- [ ] [GraphQL PR](link-to-pr-here). If this PR changes or adds API input or response fields, it must be added to the GraphQL API before this PR to the server SDK can be merged in.
- [ ] Add & Run integration tests -->
