### PR TITLE
Add `default?` attribute in PaymentMethodNonce

### DIFF
--- a/lib/braintree/payment_method_nonce.rb
+++ b/lib/braintree/payment_method_nonce.rb
@@ -29,6 +29,8 @@ module Braintree
       @authentication_insight = attributes.fetch(:authentication_insight, nil)
       @three_d_secure_info = ThreeDSecureInfo.new(attributes[:three_d_secure_info]) if attributes[:three_d_secure_info]
       @bin_data = BinData.new(attributes[:bin_data]) if attributes[:bin_data]
+
+      define_method 'default?', {|_| attributes.fetch(:default)}
     end
 
     def to_s # :nodoc:


### PR DESCRIPTION
# Summary

Add `default?` attribute in PaymentMethodNonce. 

I will add a changelog entry and unit tests if this change is accepted.

see: https://developers.braintreepayments.com/reference/response/payment-method-nonce/ruby#default

# Checklist

- [ ] Added changelog entry (If there isn't an `#unreleased` section, add that and your changelog entry to the top of the changelog)
- [ ] Ran unit tests (`rake test:unit`)
