### PR TITLE
Describe ArgumentError when id is nil or empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Add a log message to the `ArgumentError` at `TransactionGateway.find`
+
 # Changelog
 
 ## 4.2.0

--- a/lib/braintree/transaction_gateway.rb
+++ b/lib/braintree/transaction_gateway.rb
@@ -61,7 +61,7 @@ module Braintree
     end
 
     def find(id)
-      raise ArgumentError if id.nil? || id.strip.to_s == ""
+      raise ArgumentError, "id can not be empty" if id.nil? || id.strip.to_s == ""
       response = @config.http.get("#{@config.base_merchant_path}/transactions/#{id}")
       Transaction._new(@gateway, response[:transaction])
     rescue NotFoundError

--- a/spec/unit/braintree/transaction_spec.rb
+++ b/spec/unit/braintree/transaction_spec.rb
@@ -21,19 +21,19 @@ describe Braintree::Transaction do
     it "raises error if passed empty string" do
       expect do
         Braintree::Transaction.find("")
-      end.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError, "id can not be empty")
     end
 
     it "raises error if passed empty string wth space" do
       expect do
         Braintree::Transaction.find(" ")
-      end.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError, "id can not be empty")
     end
 
     it "raises error if passed nil" do
       expect do
         Braintree::Transaction.find(nil)
-      end.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError, "id can not be empty")
     end
   end
 


### PR DESCRIPTION
# Summary

Got an unclear error while using the lib and had to dig around to understand better what caused an `ArgumentError` at our project at @nuuvem, and the `find` method at `TransactionGateway` is what caused it.

By adding a message to the ArgumentError we improve log readability, making it easier to grasp what error actually happened. 

# Checklist

- [x] Added changelog entry (If there isn't an `#unreleased` section, add that and your changelog entry to the top of the changelog)
- [x] Ran unit tests (`rake test:unit`)

