### PR TITLE
Fix tax id paypal details

### DIFF
--- a/lib/braintree/transaction/paypal_details.rb
+++ b/lib/braintree/transaction/paypal_details.rb
@@ -27,6 +27,8 @@ module Braintree
       attr_reader :token
       attr_reader :transaction_fee_amount
       attr_reader :transaction_fee_currency_iso_code
+      attr_reader :tax_id
+      attr_reader :tax_id_type
 
       def initialize(attributes)
         set_instance_variables_from_hash attributes unless attributes.nil?

--- a/spec/unit/braintree/transaction/paypal_details_spec.rb
+++ b/spec/unit/braintree/transaction/paypal_details_spec.rb
@@ -28,6 +28,8 @@ describe Braintree::Transaction::PayPalDetails do
         :token => "token",
         :transaction_fee_amount => "2.00",
         :transaction_fee_currency_iso_code => "123",
+        :tax_id => '232323232323',
+        :tax_id_type => 'BR_CPF'
       )
 
       expect(details.authorization_id).to eq("id")
@@ -54,6 +56,8 @@ describe Braintree::Transaction::PayPalDetails do
       expect(details.token).to eq("token")
       expect(details.transaction_fee_amount).to eq("2.00")
       expect(details.transaction_fee_currency_iso_code).to eq("123")
+      expect(details.tax_id).to eq("232323232323")
+      expect(details.tax_id_type).to eq("BR_CPF")
     end
   end
 end


### PR DESCRIPTION
# Summary

Fix this issue: https://github.com/braintree/braintree_ruby/issues/218

# Checklist

- [x] Added method access to tax_id and tax_id_type on Transaction::PaylpalDetails
- [x] Ran unit tests (`rake test:unit`)
