### PR TITLE
Fix errors handle on plan create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix issue #223: Replace 'errors' with expected 'api_error_response'
+
 # Changelog
 
 ## 4.5.0

--- a/lib/braintree/plan_gateway.rb
+++ b/lib/braintree/plan_gateway.rb
@@ -106,10 +106,10 @@ module Braintree
       response = @config.http.post("#{@config.base_merchant_path}#{path}", params)
       if response[:plan]
         SuccessfulResult.new(:plan => Plan._new(@gateway, response[:plan]))
-      elsif response[:errors]
-        ErrorResult.new(@gateway, response[:errors])
+      elsif response[:api_error_response]
+        ErrorResult.new(@gateway, response[:api_error_response])
       else
-        raise UnexpectedError, "expected :plan or :errors"
+        raise UnexpectedError, "expected :plan or :api_error_response"
       end
     end
   end


### PR DESCRIPTION
# Summary

Fix for https://github.com/braintree/braintree_ruby/issues/223

# Checklist

- [x] Added changelog entry (If there isn't an `#unreleased` section, add that and your changelog entry to the top of the changelog)
- [x] Ran unit tests (`rake test:unit`)
