### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+---
+name: Tests
+on: [ push, pull_request ]
+jobs:
+  test:
+    name: Unit test (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '3.3', '3.2', '3.1', '3.0', '2.7', '2.6' ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake test:unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Use GitHub Actions to automatically run unit tests against all supported versions of Ruby. This workflow is triggered on git commit pushes and pull requests.
+
 ## 4.18.0
 
 - Add `process_debit_as_credit` to `credit_card` field in `options` field during Transaction create

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "builder", "3.2.4"
 gem "libxml-ruby", "3.2.0"
 
 group :development do
-  gem "pry", "0.13.1"
+  gem "pry", "0.14.2"
   gem "rake", "13.0.1"
   gem "rspec", "3.9.0"
   gem "rubocop", "1.50.2"


### PR DESCRIPTION
### Summary

To give external development teams and the wider community confidence that this project is compatible with the latest versions of Ruby, I propose using GitHub Actions to automatically run the unit tests against a matrix of supported Ruby versions.

This GitHub workflow is [passing on my fork](https://github.com/orien/braintree_ruby/actions/runs/7962530198) and will be added to this project upon merge.

### Checklist

- [x] Added changelog entry (If there isn't an `#unreleased` section, add that and your changelog entry to the top of the changelog)
- [x] Ran unit tests (`rake test:unit`)
- [x] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main

