### PR TITLE
Add dependencies to quiet warnings and prepare for Ruby 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add gems that are no longer standard libraries / default gems to Gemfile and gemspec
+
 ## 4.33.0
 - Switch from libxml-ruby to Nokogiri to allow use with JRuby. 
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source "https://rubygems.org"
 gem "builder", "3.2.4"
 gem "nokogiri", "~> 1.12"
 gem "require_all", "3.0.0"
+gem "base64", ">= 0.3.0"
+gem "bigdecimal", ">= 3.3.1"
+gem "logger", ">= 1.7.0"
+gem "ostruct", ">= 0.6.3"
 
 group :development do
   gem "pry", "0.13.1"

--- a/braintree.gemspec
+++ b/braintree.gemspec
@@ -13,6 +13,10 @@ Gem::Specification.new do |s|
   s.files = Dir.glob ["README.rdoc", "LICENSE", "lib/**/*.{rb,crt}", "spec/**/*", "*.gemspec"]
   s.add_dependency "builder", ">= 3.2.4"
   s.add_dependency "rexml", ">= 3.1.9" # Use rexml version associated with minimum supported Ruby version
+  s.add_dependency "base64", ">= 0.3.0"
+  s.add_dependency "bigdecimal", ">= 3.3.1"
+  s.add_dependency "logger", ">= 1.7.0"
+  s.add_dependency "ostruct", ">= 0.6.3"
   s.required_ruby_version = ">=2.6.0"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/braintree/braintree_ruby/issues",


### PR DESCRIPTION
# Summary

Fixes https://github.com/braintree/braintree_ruby/issues/250

# Checklist
- [x] Added changelog entry (If there isn't an `#unreleased` section, add that and your changelog entry to the top of the changelog)

- [x] Ran unit tests (`rake test:unit`):
Note: to get the tests to run on Ruby 3.2 and 3.3, i had to temporarily remove the `require "pry"` line from spec/spec_helper.rb. That change is not part of this PR because its part of the larger issue of getting the tests working on modern, maintained Ruby versions. I also don't know if pry is still required for integration tests, so i didn't want to remove it. All unit tests passed on Ruby 3.2 and 3.3. Testing on Ruby 3.4 succeeded except for two trivial failures related to expecting the old representation of hashes (i.e. `{:a => "b"}` as opposed to `{a: "b"}`

- [x] I alphabetized all attributes, parameters, and methods by name in any class file I changed

- [x] I have linked the JIRA ticket in the summary section
not applicable

- [x] I have reviewed the JIRA ticket to ensure all AC's are met
not applicable

- [x] I understand that unless this is a Draft PR or has a DO NOT MERGE label, this PR is considered to be in a deploy ready state and can be deployed if merged to main

<!-- **For Braintree Developers only, don't forget:**
- [ ] [GraphQL PR](link-to-pr-here). If this PR changes or adds API input or response fields, it must be added to the GraphQL API before this PR to the server SDK can be merged in.
- [ ] Add & Run integration tests -->
